### PR TITLE
fix: stop logging the FlexMeasures credentials on every websocket connection

### DIFF
--- a/custom_components/flexmeasures_hacs/manifest.json
+++ b/custom_components/flexmeasures_hacs/manifest.json
@@ -1,15 +1,22 @@
 {
   "domain": "flexmeasures_hacs",
   "name": "FlexMeasures for HACS",
-  "codeowners": ["@Flix6x"],
+  "codeowners": [
+    "@Flix6x"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
-  "documentation": "https://github.com/FlexMeasures/flexmeasures-hacs#flexmeasures",  
+  "dependencies": [
+    "http"
+  ],
+  "documentation": "https://github.com/FlexMeasures/flexmeasures-hacs#flexmeasures",
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/FlexMeasures/flexmeasures-hacs/issues",
-  "requirements": ["flexmeasures-client[s2]==0.9.3", "isodate==0.6.1"],
+  "requirements": [
+    "flexmeasures-client[s2]==0.9.3",
+    "isodate==0.6.1"
+  ],
   "ssdp": [],
-  "version": "0.3.8",
+  "version": "0.3.9",
   "zeroconf": []
 }

--- a/custom_components/flexmeasures_hacs/websockets.py
+++ b/custom_components/flexmeasures_hacs/websockets.py
@@ -77,7 +77,6 @@ class WebSocketHandler:
 
         self._logger = WebSocketAdapter(_WS_LOGGER, {"connid": id(self)})
         self._logger.debug("new websockets connection")
-        self._logger.warning(hass.data[DOMAIN][FM_CLIENT])
 
         frbc_data: FRBC_Config = hass.data[DOMAIN][FRBC_CONFIG]
         self._logger.info(

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -2,7 +2,32 @@
 
 # pytest ./tests/components/flexmeasures/ --cov=homeassistant.components.flexmeasures --cov-report term-missing -vv
 
+import logging
+
+import pytest
+
 from homeassistant.core import HomeAssistant
+
+
+async def test_websocket_connection_does_not_log_credentials(
+    hass: HomeAssistant,
+    setup_fm_integration,
+    fm_ws_client,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Opening a websocket connection must not leak the FlexMeasures credentials.
+
+    Up to v0.3.8, the handler logged the whole FlexMeasuresClient at WARNING
+    level. It is a dataclass, so its repr contains the password in plain text,
+    which ended up in the Home Assistant log on every connection.
+    """
+    password = setup_fm_integration.data["password"]
+    with caplog.at_level(logging.DEBUG):
+        await fm_ws_client(hass)
+        await hass.async_block_till_done()
+
+    assert password not in caplog.text
+    assert setup_fm_integration.data["username"] not in caplog.text
 
 
 async def test_cem_processes_websocket_msg(


### PR DESCRIPTION
## The problem

`WebSocketHandler.__init__` logged the whole `FlexMeasuresClient` at **WARNING** level on every incoming S2 websocket connection:

```python
self._logger.warning(hass.data[DOMAIN][FM_CLIENT])
```

`FlexMeasuresClient` is a dataclass, so its `repr()` contains the configured credentials in plain text:

```
FlexMeasuresClient(password='SUPERSECRET', email='user@example.com', host='example.com', ...)
```

So the FlexMeasures **password and username of every install running the S2/TUNES websocket are written into the Home Assistant log** — at WARNING, so they survive default log levels, and they land in any log bundle a user shares for support. This is in the released v0.3.8 (the line came in as a leftover debug statement on `fix/tunes-cem`).

## The fix

Remove the line, and add a regression test that opens a websocket connection and asserts neither the password nor the username appears in the captured log. Verified the test **fails against the v0.3.8 code** and passes with the fix.

Manifest bumped to 0.3.9 so this can go out as a patch release ahead of the larger v0.4.0 modernization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
