### PR TITLE
v0.4.0: several FlexMeasures servers, plus modernization for Home Assistant 2026.7

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,7 +58,9 @@ jobs:
         run: |
           docker logs ha > ha.log 2>&1
           grep -q "Setting up flexmeasures_hacs" ha.log
+          # The seeded entry is an old (v2) one, so the whole migration chain runs.
           grep -q "Migrating configuration from version 2" ha.log
+          grep -q "Migration to configuration version 4" ha.log
           ! grep -E "ERROR.*(flexmeasures_hacs|flexmeasures_client)" ha.log
 
       - name: Check dependency consistency inside Home Assistant

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,18 +47,33 @@ jobs:
     steps:
       - name: Check out src from Git
         uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      # Install with uv, because that is what Home Assistant itself uses to
+      # install an integration's requirements. It matters here: s2-python still
+      # declares Requires-Python <3.14, which pip enforces and uv does not, so
+      # pip cannot install flexmeasures-client[s2] on the Python that Home
+      # Assistant 2026.7 runs on -- while Home Assistant can, and does (the
+      # smoke test proves the S2 path works inside a real HA container).
+      # Installing the way production installs is the whole point: a test
+      # environment that resolves differently from the real one is what let the
+      # broken v0.3.7 release through in the first place.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+      - name: Create the virtual environment
+        run: |
+          uv venv --python ${{ env.PYTHON_VERSION }}
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Install test requirements
-        run: pip install -r requirements.test.txt
+        run: uv pip install -r requirements.test.txt
 
       - name: Install integration requirements from the manifest
         # Tests must run against the exact versions Home Assistant installs for
         # users. tests/test_manifest.py guards that this step stays in sync.
         run: |
-          pip install $(python -c "import json; print(' '.join(json.load(open('custom_components/flexmeasures_hacs/manifest.json'))['requirements']))")
+          uv pip install $(python -c "import json; print(' '.join(json.load(open('custom_components/flexmeasures_hacs/manifest.json'))['requirements']))")
 
       - name: Run all tests except those marked to be skipped by GitHub AND record coverage
         run: pytest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,15 +2,21 @@ name: Validate
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+
+env:
+  # Home Assistant 2026.7 runs on Python 3.14, and so does the pinned
+  # pytest-homeassistant-custom-component.
+  PYTHON_VERSION: "3.14"
 
 jobs:
   validate-hacs:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - name: HACS validation
         uses: "hacs/action@main"
         with:
@@ -24,29 +30,24 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    name: Check (on Python 3.12)
+    name: Check
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-      - uses: actions/checkout@v3
-      - uses: pre-commit/action@v3.0.0
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: pre-commit/action@v3.0.1
 
   test:
     needs: check
     runs-on: ubuntu-latest
-    name: "Test (on Python 3.12)"
+    name: "Test (on Python ${{ env.PYTHON_VERSION }})"
     steps:
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.12
-
       - name: Check out src from Git
-        uses: actions/checkout@v3
-      - name: Get history and tags for SCM versioning to work
-        run: |
-          git fetch --prune --unshallow
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install test requirements
         run: pip install -r requirements.test.txt

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,7 +41,9 @@ jobs:
   test:
     needs: check
     runs-on: ubuntu-latest
-    name: "Test (on Python ${{ env.PYTHON_VERSION }})"
+    # The `env` context is not available in a job's `name`, so the version is
+    # spelled out here; PYTHON_VERSION above is what actually gets installed.
+    name: "Test (on Python 3.14)"
     steps:
       - name: Check out src from Git
         uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,14 @@
 repos:
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+  # Ruff replaces flake8, isort, black and pyupgrade, which used to run here
+  # (and in setup.cfg) side by side, with partly contradicting settings.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.4
     hooks:
-      - id: pyupgrade
-        args: [--py37-plus]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        files: ^((homeassistant|script|tests)/.+)?[^/]+\.py$
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:
@@ -21,14 +16,8 @@ repos:
           - --skip="./.*,*.csv,*.json"
           - --quiet-level=2
         exclude_types: [csv, json]
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.4.8
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.14.1
     hooks:
       - id: mypy
         args:

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,32 @@
+# Ruff is the single linter/formatter here (it replaced flake8, isort, black
+# and pyupgrade). Settings follow Home Assistant core's conventions.
+target-version = "py313"
+line-length = 88
+
+[lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "SIM",  # flake8-simplify
+    "RUF",  # ruff-specific rules
+]
+ignore = [
+    "E501",  # line length is handled by the formatter
+]
+
+[lint.isort]
+force-sort-within-sections = true
+known-first-party = ["custom_components", "tests"]
+combine-as-imports = true
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "local-folder",
+]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ data:
   soc_at_start: "\{\{ state_attr\('SENSOR_TYPE.SENSOR', 'SENSOR_ATTRIBUTES'\) \}\}"
 ```
 
+## Which FlexMeasures server version you need
+
+This integration ships flexmeasures-client 0.9.x, which posts and reads sensor data through endpoints that FlexMeasures serves from **0.28.0** on (triggering a schedule needs **0.27.0**). Against an older server, the integration still loads, but `post_measurements` and `get_measurements` fail when they are called. The integration logs a warning at startup when it finds a server that is too old.
+
+Integration versions up to v0.3.6 shipped client 0.7.0, which still used the deprecated endpoints — so this is worth checking before upgrading from v0.3.6 or earlier.
+
 ## Several FlexMeasures servers
 
 You can add the integration more than once, to talk to several FlexMeasures servers (or several accounts on one server) from the same Home Assistant. Each entry gets its own device, its own schedule sensor and its own S2 session.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ data:
   soc_at_start: "\{\{ state_attr\('SENSOR_TYPE.SENSOR', 'SENSOR_ATTRIBUTES'\) \}\}"
 ```
 
+## Upgrading and rolling back
+
+Upgrading is handled for you: the integration migrates its configuration entry, keeping your settings, your schedule sensor (and its history) and the stored S2 state.
+
+Rolling back to an older release is a different matter. Home Assistant does not support downgrading a configuration entry across a major version — an older release refuses an entry it does not understand, and leaves it in a "migration error" state. To roll back: remove the integration in Settings > Devices & services, install the older version in HACS, and add the integration again. The S2 state that older releases use is left in place, so it survives the round trip.
+
 ## Which FlexMeasures server version you need
 
 This integration ships flexmeasures-client 0.9.x, which posts and reads sensor data through endpoints that FlexMeasures serves from **0.28.0** on (triggering a schedule needs **0.27.0**). Against an older server, the integration still loads, but `post_measurements` and `get_measurements` fail when they are called. The integration logs a warning at startup when it finds a server that is too old.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ friendly_name: FlexMeasures Schedule
 For a schedule to be calculated a `soc_at_start` is required. All other variables needed to calculate a new schedule were provided in the configuration. The following `yaml` file will trigger a schedule and update the sensor:
 
 ```
-service: flexmeasures.trigger_and_get_schedule
+action: flexmeasures_hacs.trigger_and_get_schedule
 data:
   soc_at_start: "FLOAT_SOC_AT_START"
 ```
@@ -116,10 +116,25 @@ data:
 The intended usage of FlexMeasures is letting the schedules and Home Assistant optimize the flexible energy assets without user interaction. Automations can be used to trigger new schedules when new information is available that would impact the schedule. Some examples of events that should trigger the request of new schedules are when the battery/asset is connected, when new prices are available, and periodically to match the executed schedule to the calculated schedule. The user will need to provide a Home Assistant entity as a `soc_at_start` to be used for triggering a schedule. This is an example `yaml` for the action set in the automations:
 
 ```
-service: flexmeasures.trigger_and_get_schedule
+action: flexmeasures_hacs.trigger_and_get_schedule
 data:
   soc_at_start: "\{\{ state_attr\('SENSOR_TYPE.SENSOR', 'SENSOR_ATTRIBUTES'\) \}\}"
 ```
+
+## Several FlexMeasures servers
+
+You can add the integration more than once, to talk to several FlexMeasures servers (or several accounts on one server) from the same Home Assistant. Each entry gets its own device, its own schedule sensor and its own S2 session.
+
+With more than one entry configured, say which one an action is for:
+
+```
+action: flexmeasures_hacs.trigger_and_get_schedule
+data:
+  soc_at_start: "FLOAT_SOC_AT_START"
+  entry_id: "THE_CONFIG_ENTRY_ID"
+```
+
+and connect a Resource Manager to the entry's own websocket endpoint, `/api/websocket_custom/<entry_id>`. With a single entry configured, both the `entry_id` field and the path suffix can be left out.
 
 ## Development
 

--- a/custom_components/flexmeasures_hacs/__init__.py
+++ b/custom_components/flexmeasures_hacs/__init__.py
@@ -258,7 +258,13 @@ async def _async_migrate_unique_ids(
 async def _async_migrate_datastore(
     hass: HomeAssistant, entry: FlexMeasuresConfigEntry
 ) -> None:
-    """Move the shared S2 datastore to a store belonging to this config entry."""
+    """Copy the shared S2 datastore into a store belonging to this config entry.
+
+    The legacy store is deliberately left in place. Home Assistant does not
+    support downgrading a config entry across a major version, so rolling back
+    to an older release means removing and re-adding the entry -- and that older
+    release reads the S2 state from exactly this legacy store.
+    """
     legacy_store: Store = Store(hass, version=STORAGE_VERSION, key=LEGACY_STORAGE_KEY)
     legacy_data = await legacy_store.async_load()
     if not legacy_data:
@@ -272,8 +278,7 @@ async def _async_migrate_datastore(
         return
 
     await entry_store.async_save(legacy_data)
-    await legacy_store.async_remove()
-    _LOGGER.debug("Migrated the S2 datastore to config entry %s", entry.entry_id)
+    _LOGGER.debug("Copied the S2 datastore to config entry %s", entry.entry_id)
 
 
 __all__ = [

--- a/custom_components/flexmeasures_hacs/__init__.py
+++ b/custom_components/flexmeasures_hacs/__init__.py
@@ -6,36 +6,55 @@ from dataclasses import fields
 import logging
 
 from flexmeasures_client import FlexMeasuresClient
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigValidationError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
 
 from .config_flow import get_host_and_ssl_from_url
-from .const import DATASTORE, DOMAIN, FM_CLIENT, FRBC_CONFIG, TIMERS
+from .const import DOMAIN, SCHEDULE_ENTITY
 from .control_types import FRBC_Config
+from .datastore import (
+    LEGACY_STORAGE_KEY,
+    STORAGE_VERSION,
+    PersistentDatastore,
+    storage_key,
+)
+from .models import FlexMeasuresConfigEntry, FlexMeasuresRuntimeData
 from .services import (
     async_setup_services,
     async_unload_services,
     get_from_option_or_config,
 )
-from .websockets import WebsocketAPIView
+from .websockets import async_register_websocket_view
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
+# Fields of FRBC_Config that live outside the "s2" section of the config entry.
+NON_S2_FIELDS = (
+    "consumption_price_sensor",
+    "production_price_sensor",
+    "schedule_duration",
+)
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: FlexMeasuresConfigEntry
+) -> bool:
     """Set up FlexMeasures from a config entry."""
-
-    hass.data.setdefault(DOMAIN, {})
 
     # Reload integration when the options are updated
     entry.async_on_unload(entry.add_update_listener(options_update_listener))
+
+    if get_from_option_or_config("schedule_duration", entry) is None:
+        raise ConfigValidationError(
+            message="Schedule duration is not set", exceptions=[]
+        )
 
     host, ssl = get_host_and_ssl_from_url(get_from_option_or_config("url", entry))
     client = FlexMeasuresClient(
@@ -47,71 +66,65 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         logger=_LOGGER,
     )
 
-    # store config
-    # if schedule_duration is not set, throw an error
-    if get_from_option_or_config("schedule_duration", entry) is None:
-        raise ConfigValidationError(
-            message="Schedule duration is not set", exceptions=[]
-        )
-
-    frbc_data_dict = {}
-
-    non_s2_fields = [
-        "consumption_price_sensor",
-        "production_price_sensor",
-        "schedule_duration",
-    ]
-
-    for field in fields(FRBC_Config):
-        if field.name in non_s2_fields:
-            frbc_data_dict[field.name] = get_from_option_or_config(field.name, entry)
-        else:
-            frbc_data_dict[field.name] = get_from_option_or_config(
-                field.name, entry, section="s2"
+    frbc_config = FRBC_Config(
+        **{
+            f.name: get_from_option_or_config(
+                f.name,
+                entry,
+                section=None if f.name in NON_S2_FIELDS else "s2",
             )
+            for f in fields(FRBC_Config)
+        }
+    )
 
-    FRBC_data = FRBC_Config(**frbc_data_dict)
-    hass.data[DOMAIN][FRBC_CONFIG] = FRBC_data
-
-    hass.data[DOMAIN][FM_CLIENT] = client
-    hass.data[DOMAIN][TIMERS] = {}
-
-    # Create a persistent datastore
-    datastore = PersistentDatastore(hass, DOMAIN)
+    datastore = PersistentDatastore(hass, storage_key(entry.entry_id))
     await datastore.async_load()
-    hass.data[DOMAIN][DATASTORE] = datastore
 
-    hass.http.register_view(WebsocketAPIView(entry))
+    entry.runtime_data = FlexMeasuresRuntimeData(
+        client=client,
+        frbc_config=frbc_config,
+        datastore=datastore,
+    )
 
+    async_register_websocket_view(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    await async_setup_services(hass, entry)
+    async_setup_services(hass)
 
     return True
 
 
-async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+async def options_update_listener(
+    hass: HomeAssistant, config_entry: FlexMeasuresConfigEntry
+) -> None:
     """Handle options update."""
 
     _LOGGER.debug("Configuration options updated, reloading FlexMeasures integration")
     await hass.config_entries.async_reload(config_entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: FlexMeasuresConfigEntry
+) -> bool:
     """Unload a config entry."""
-    if DOMAIN not in hass.data:
-        return True
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    # Remove services
-    await async_unload_services(hass)
-
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+    if unload_ok:
+        # Services are registered for the integration as a whole, so only drop
+        # them once the last entry goes away.
+        remaining = [
+            other
+            for other in hass.config_entries.async_loaded_entries(DOMAIN)
+            if other.entry_id != entry.entry_id
+        ]
+        if not remaining:
+            async_unload_services(hass)
 
     return unload_ok
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry):
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: FlexMeasuresConfigEntry
+) -> bool:
     """Migrate old entry."""
     _LOGGER.debug(
         "Migrating configuration from version %s.%s",
@@ -119,22 +132,20 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         config_entry.minor_version,
     )
 
-    if config_entry.version > 3:
+    if config_entry.version > 4:
         # This means the user has downgraded from a future version
         return False
 
     if config_entry.version == 1:
-        from .config_flow import S2_SCHEMA
+        from .config_flow import S2_SCHEMA, schema_defaults
 
         new_data = {**config_entry.data} | {**config_entry.options}
-        new_data["s2"] = {}
-
-        for field in S2_SCHEMA.schema.keys():
-            field_name = str(field)
-            if field_name in new_data:
-                new_data["s2"][field_name] = new_data[field_name]
-            elif hasattr(field, "default"):
-                new_data["s2"][field_name] = field.default()
+        s2_defaults = schema_defaults(S2_SCHEMA)
+        new_data["s2"] = {
+            field: new_data.get(field, s2_defaults.get(field))
+            for field in (str(field) for field in S2_SCHEMA.schema)
+            if field in new_data or field in s2_defaults
+        }
 
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=2)
 
@@ -142,7 +153,7 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
         # v3 renames the misspelled leakage_beaviour_sensor_id (which client
         # versions >=0.8 no longer accept) and fills S2 fields that did not
         # exist when the entry was created (e.g. asset_id).
-        from .config_flow import S2_SCHEMA
+        from .config_flow import S2_SCHEMA, schema_defaults
 
         def migrate_s2_section(s2: dict, fill_defaults: bool) -> dict:
             s2 = {**s2}
@@ -152,10 +163,8 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
                     s2.pop("leakage_beaviour_sensor_id"),
                 )
             if fill_defaults:
-                for field in S2_SCHEMA.schema.keys():
-                    field_name = str(field)
-                    if field_name not in s2 and hasattr(field, "default"):
-                        s2[field_name] = field.default()
+                for field, default in schema_defaults(S2_SCHEMA).items():
+                    s2.setdefault(field, default)
             return s2
 
         new_data = {**config_entry.data}
@@ -173,6 +182,16 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             config_entry, data=new_data, options=new_options, version=3
         )
 
+    if config_entry.version == 3:
+        # v4 makes runtime state per config entry, so that several FlexMeasures
+        # servers can be configured side by side. The schedule sensor and the
+        # datastore used to be shared; give them entry-scoped identities while
+        # keeping the existing entity (and its history) and the stored S2 state.
+        await _async_migrate_unique_ids(hass, config_entry)
+        await _async_migrate_datastore(hass, config_entry)
+
+        hass.config_entries.async_update_entry(config_entry, version=4)
+
     _LOGGER.debug(
         "Migration to configuration version %s.%s successful",
         config_entry.version,
@@ -182,32 +201,45 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
     return True
 
 
-class PersistentDatastore(dict):
-    def __init__(self, hass, domain: str, version: int = 1, save_delay: float = 5.0):
-        super().__init__()
-        self.hass = hass
-        self._store = Store(hass, version=version, key=f"{domain}_datastore")
-        self._initialized = False
-        self._save_handle = None
-        self._save_delay = save_delay
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: FlexMeasuresConfigEntry
+) -> None:
+    """Scope the schedule sensor's unique id to the config entry."""
 
-    async def async_load(self):
-        data = await self._store.async_load() or {}
-        self.clear()
-        self.update(data)
-        self._initialized = True
+    @callback
+    def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+        if entity_entry.unique_id == SCHEDULE_ENTITY:
+            return {"new_unique_id": f"{entry.entry_id}_{SCHEDULE_ENTITY}"}
+        return None
 
-    async def async_save(self):
-        if not self._initialized:
-            raise RuntimeError("Datastore not loaded yet")
-        await self._store.async_save(dict(self))
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate)
 
-    def __setitem__(self, key, value):
-        super().__setitem__(key, value)
-        hass = self._store.hass
-        hass.loop.create_task(self._store.async_save(dict(self)))
 
-    def __delitem__(self, key):
-        super().__delitem__(key)
-        hass = self._store.hass
-        hass.loop.create_task(self._store.async_save(dict(self)))
+async def _async_migrate_datastore(
+    hass: HomeAssistant, entry: FlexMeasuresConfigEntry
+) -> None:
+    """Move the shared S2 datastore to a store belonging to this config entry."""
+    legacy_store: Store = Store(hass, version=STORAGE_VERSION, key=LEGACY_STORAGE_KEY)
+    legacy_data = await legacy_store.async_load()
+    if not legacy_data:
+        return
+
+    entry_store: Store = Store(
+        hass, version=STORAGE_VERSION, key=storage_key(entry.entry_id)
+    )
+    if await entry_store.async_load():
+        # Already migrated (or this entry has state of its own); don't clobber it.
+        return
+
+    await entry_store.async_save(legacy_data)
+    await legacy_store.async_remove()
+    _LOGGER.debug("Migrated the S2 datastore to config entry %s", entry.entry_id)
+
+
+__all__ = [
+    "ConfigEntry",
+    "FlexMeasuresConfigEntry",
+    "async_migrate_entry",
+    "async_setup_entry",
+    "async_unload_entry",
+]

--- a/custom_components/flexmeasures_hacs/__init__.py
+++ b/custom_components/flexmeasures_hacs/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.exceptions import ConfigValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.storage import Store
+from packaging.version import Version
 
 from .config_flow import get_host_and_ssl_from_url
 from .const import DOMAIN, SCHEDULE_ENTITY
@@ -34,6 +35,13 @@ from .websockets import async_register_websocket_view
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+# flexmeasures-client >=0.8 posts and reads sensor data through endpoints that
+# FlexMeasures only serves from 0.28.0 on (scheduling needs 0.27.0). Against an
+# older server those calls 404 at the moment a service runs, so check the server
+# version once at startup and say so, rather than let a nightly automation be
+# the one to find out.
+MINIMUM_SERVER_VERSION = "0.28.0"
 
 # Fields of FRBC_Config that live outside the "s2" section of the config entry.
 NON_S2_FIELDS = (
@@ -90,7 +98,39 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     async_setup_services(hass)
 
+    entry.async_create_background_task(
+        hass,
+        _async_check_server_version(client),
+        name=f"{DOMAIN}_check_server_version",
+    )
+
     return True
+
+
+async def _async_check_server_version(client: FlexMeasuresClient) -> None:
+    """Warn when the FlexMeasures server is too old for the client we ship.
+
+    Deliberately does not block or fail the setup: an unreachable server is a
+    separate problem, and the schedule sensor and the S2 path are useful even
+    while we cannot tell the version.
+    """
+    try:
+        versions = await client.get_versions()
+        server_version = versions.get("server_version")
+        if server_version is None:
+            return
+        if Version(server_version) < Version(MINIMUM_SERVER_VERSION):
+            _LOGGER.warning(
+                "This FlexMeasures server runs version %s, but posting and reading"
+                " sensor data needs %s or above (scheduling needs 0.27.0). Those"
+                " service calls will fail until the server is upgraded",
+                server_version,
+                MINIMUM_SERVER_VERSION,
+            )
+    except Exception:
+        _LOGGER.debug(
+            "Could not determine the FlexMeasures server version", exc_info=True
+        )
 
 
 async def options_update_listener(

--- a/custom_components/flexmeasures_hacs/config_flow.py
+++ b/custom_components/flexmeasures_hacs/config_flow.py
@@ -7,8 +7,6 @@ from typing import Any, cast
 
 from flexmeasures_client import FlexMeasuresClient
 from flexmeasures_client.exceptions import EmailValidationError
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import async_get_hass
 from homeassistant.data_entry_flow import FlowResult, section
@@ -19,93 +17,65 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowError,
     SchemaFlowFormStep,
 )
+import voluptuous as vol
 
 from .const import DOMAIN
 
-
-S2_SCHEMA = vol.Schema(
-    {
-        vol.Optional(
-            "asset_id", default=113, description={"suggested_value": 113}
-        ): int,
-        vol.Optional(
-            "consumption_sensor_id", default=357, description={"suggested_value": 357}
-        ): int,
-        vol.Optional(
-            "soc_minima_sensor_id", default=218, description={"suggested_value": 218}
-        ): int,
-        vol.Optional(
-            "soc_maxima_sensor_id", default=217, description={"suggested_value": 217}
-        ): int,
-        vol.Optional(
-            "fill_level_sensor_id", default=215, description={"suggested_value": 215}
-        ): int,
-        vol.Optional(
-            "fill_rate_sensor_id", default=214, description={"suggested_value": 214}
-        ): int,
-        vol.Optional(
-            "usage_forecast_sensor_id",
-            default=229,
-            description={"suggested_value": 229},
-        ): int,
-        vol.Optional(
-            "thp_fill_rate_sensor_id", default=226, description={"suggested_value": 226}
-        ): int,
-        vol.Optional(
-            "thp_efficiency_sensor_id",
-            default=225,
-            description={"suggested_value": 225},
-        ): int,
-        vol.Optional(
-            "nes_fill_rate_sensor_id", default=222, description={"suggested_value": 222}
-        ): int,
-        vol.Optional(
-            "nes_efficiency_sensor_id",
-            default=221,
-            description={"suggested_value": 221},
-        ): int,
-        vol.Optional(
-            "active_actuator_id_sensor_id",
-            default=222,
-            description={"suggested_value": 222},
-        ): int,
-        vol.Optional(
-            "rm_discharge_sensor_id", default=213, description={"suggested_value": 213}
-        ): int,
-        vol.Optional(
-            "state_of_charge_sensor_id", default=2, description={"suggested_value": 2}
-        ): int,
-        vol.Optional(
-            "leakage_behaviour_sensor_id",
-            default=213,
-            description={"suggested_value": 213},
-        ): int,
-    }
+# The asset and sensor ids below identify entities on *your* FlexMeasures
+# server, so there is no sensible default for them: earlier versions shipped
+# the ids of one pilot's server, which silently pointed fresh installs at
+# somebody else's asset. They are optional because they are only needed when
+# the S2 (FRBC/TUNES) control path is used.
+S2_FIELDS = (
+    "asset_id",
+    "consumption_sensor_id",
+    "soc_minima_sensor_id",
+    "soc_maxima_sensor_id",
+    "fill_level_sensor_id",
+    "fill_rate_sensor_id",
+    "usage_forecast_sensor_id",
+    "thp_fill_rate_sensor_id",
+    "thp_efficiency_sensor_id",
+    "nes_fill_rate_sensor_id",
+    "nes_efficiency_sensor_id",
+    "active_actuator_id_sensor_id",
+    "rm_discharge_sensor_id",
+    "state_of_charge_sensor_id",
+    "leakage_behaviour_sensor_id",
 )
+
+S2_SCHEMA = vol.Schema({vol.Optional(field): vol.Any(int, None) for field in S2_FIELDS})
 
 SCHEMA = vol.Schema(
     {
-        vol.Required("url", default="https://seita.energy"): str,
-        vol.Required(
-            "username",
-            default="example@example.com",
-        ): str,
-        vol.Required("password", default="password"): str,
-        vol.Optional("power_sensor", default=5): int,
+        vol.Required("url"): str,
+        vol.Required("username"): str,
+        vol.Required("password"): str,
+        vol.Optional("power_sensor"): int,
         vol.Optional("schedule_duration", default="PT24H"): str,
-        vol.Optional(
-            "consumption_price_sensor", description={"suggested_value": 2}
-        ): int,
-        vol.Optional(
-            "production_price_sensor", description={"suggested_value": 2}
-        ): int,
-        vol.Optional("soc_sensor", description={"suggested_value": 4}): int,
+        vol.Optional("consumption_price_sensor"): int,
+        vol.Optional("production_price_sensor"): int,
+        vol.Optional("soc_sensor"): int,
         vol.Optional("soc_unit", default="kWh"): str,
-        vol.Optional("soc_min", default=10.1): vol.Coerce(float),
-        vol.Optional("soc_max", default=1.1): vol.Coerce(float),
+        vol.Optional("soc_min"): vol.Coerce(float),
+        vol.Optional("soc_max"): vol.Coerce(float),
         vol.Optional("s2"): section(S2_SCHEMA, {"collapsed": True}),
     }
 )
+
+
+def schema_defaults(schema: vol.Schema) -> dict[str, Any]:
+    """Return the fields of a schema that have a default, and their defaults.
+
+    Voluptuous sets `Marker.default` to a non-callable sentinel when a field has
+    no default, so callers cannot just call `field.default()`.
+    """
+    defaults: dict[str, Any] = {}
+    for field in schema.schema:
+        default = getattr(field, "default", vol.UNDEFINED)
+        if default is not vol.UNDEFINED and callable(default):
+            defaults[str(field)] = default()
+    return defaults
 
 
 def get_host_and_ssl_from_url(url: str) -> tuple[str, bool]:
@@ -176,7 +146,7 @@ class ConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     reauth_entry: ConfigEntry
 
-    VERSION = 3
+    VERSION = 4
 
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""

--- a/custom_components/flexmeasures_hacs/const.py
+++ b/custom_components/flexmeasures_hacs/const.py
@@ -4,15 +4,18 @@ DOMAIN = "flexmeasures_hacs"
 WS_VIEW_URI = "/api/websocket_custom"
 WS_VIEW_NAME = "websocket_custom"
 
-
 # SERVICES
 SERVICE_CHANGE_CONTROL_TYPE = "change_control_type"
 RESOLUTION = "PT15M"
-SIGNAL_UPDATE_SCHEDULE = "update_schedule"
-FM_CLIENT = "fm_client"
-FRBC_CONFIG = "frbc_config"
-SCHEDULE_STATE = "schedule"
+SIGNAL_UPDATE_SCHEDULE = "flexmeasures_hacs_update_schedule"
 SCHEDULE_ENTITY = "flexmeasures_schedule"
 SOC_UNIT = "kWh"
-TIMERS = "timers"
-DATASTORE = "datastore"
+
+# Service data field naming the config entry to act on, needed only when more
+# than one FlexMeasures server is configured.
+ATTR_ENTRY_ID = "entry_id"
+
+
+def signal_update_schedule(entry_id: str) -> str:
+    """Return the dispatcher signal for schedule updates of one config entry."""
+    return f"{SIGNAL_UPDATE_SCHEDULE}_{entry_id}"

--- a/custom_components/flexmeasures_hacs/datastore.py
+++ b/custom_components/flexmeasures_hacs/datastore.py
@@ -1,0 +1,73 @@
+"""Persistent storage for the S2 CEM, surviving Home Assistant restarts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+STORAGE_VERSION = 1
+LEGACY_STORAGE_KEY = f"{DOMAIN}_datastore"
+
+SAVE_DELAY = 5.0
+
+
+def storage_key(entry_id: str) -> str:
+    """Return the storage key holding the datastore of one config entry."""
+    return f"{DOMAIN}_{entry_id}_datastore"
+
+
+class PersistentDatastore(dict):
+    """A dict that persists itself, so the CEM keeps its state across restarts.
+
+    Writes are debounced: the CEM mutates the datastore per incoming S2 message,
+    and we do not want a disk write for each of them.
+    """
+
+    def __init__(
+        self, hass: HomeAssistant, key: str, save_delay: float = SAVE_DELAY
+    ) -> None:
+        """Initialize the datastore, backed by the store under the given key."""
+        super().__init__()
+        self.hass = hass
+        self._store: Store = Store(hass, version=STORAGE_VERSION, key=key)
+        self._save_delay = save_delay
+        self._initialized = False
+
+    async def async_load(self) -> None:
+        """Load the persisted contents into this dict."""
+        data = await self._store.async_load() or {}
+        self.clear()
+        self.update(data)
+        self._initialized = True
+
+    async def async_save(self) -> None:
+        """Persist the current contents immediately."""
+        if not self._initialized:
+            raise RuntimeError("Datastore not loaded yet")
+        await self._store.async_save(dict(self))
+
+    def _data_to_save(self) -> dict[str, Any]:
+        return dict(self)
+
+    def _schedule_save(self) -> None:
+        if not self._initialized:
+            return
+        # The CEM may mutate the datastore from another thread's event loop, so
+        # hand the (loop-bound) delayed save back to Home Assistant's own loop.
+        self.hass.loop.call_soon_threadsafe(
+            self._store.async_delay_save, self._data_to_save, self._save_delay
+        )
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        """Set a key and schedule a save."""
+        super().__setitem__(key, value)
+        self._schedule_save()
+
+    def __delitem__(self, key: Any) -> None:
+        """Delete a key and schedule a save."""
+        super().__delitem__(key)
+        self._schedule_save()

--- a/custom_components/flexmeasures_hacs/manifest.json
+++ b/custom_components/flexmeasures_hacs/manifest.json
@@ -10,7 +10,7 @@
   ],
   "documentation": "https://github.com/FlexMeasures/flexmeasures-ha-integration#flexmeasures",
   "integration_type": "service",
-  "iot_class": "cloud_push",
+  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/FlexMeasures/flexmeasures-ha-integration/issues",
   "requirements": [
     "flexmeasures-client[s2]==0.9.3"

--- a/custom_components/flexmeasures_hacs/manifest.json
+++ b/custom_components/flexmeasures_hacs/manifest.json
@@ -8,15 +8,12 @@
   "dependencies": [
     "http"
   ],
-  "documentation": "https://github.com/FlexMeasures/flexmeasures-hacs#flexmeasures",
-  "homekit": {},
-  "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/FlexMeasures/flexmeasures-hacs/issues",
+  "documentation": "https://github.com/FlexMeasures/flexmeasures-ha-integration#flexmeasures",
+  "integration_type": "service",
+  "iot_class": "cloud_push",
+  "issue_tracker": "https://github.com/FlexMeasures/flexmeasures-ha-integration/issues",
   "requirements": [
-    "flexmeasures-client[s2]==0.9.3",
-    "isodate==0.6.1"
+    "flexmeasures-client[s2]==0.9.3"
   ],
-  "ssdp": [],
-  "version": "0.3.9",
-  "zeroconf": []
+  "version": "0.4.0"
 }

--- a/custom_components/flexmeasures_hacs/manifest.json
+++ b/custom_components/flexmeasures_hacs/manifest.json
@@ -1,15 +1,22 @@
 {
   "domain": "flexmeasures_hacs",
   "name": "FlexMeasures for HACS",
-  "codeowners": ["@Flix6x"],
+  "codeowners": [
+    "@Flix6x"
+  ],
   "config_flow": true,
-  "dependencies": ["http"],
-  "documentation": "https://github.com/FlexMeasures/flexmeasures-hacs#flexmeasures",  
+  "dependencies": [
+    "http"
+  ],
+  "documentation": "https://github.com/FlexMeasures/flexmeasures-hacs#flexmeasures",
   "homekit": {},
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/FlexMeasures/flexmeasures-hacs/issues",
-  "requirements": ["flexmeasures-client[s2]==0.9.3", "isodate==0.6.1"],
+  "requirements": [
+    "flexmeasures-client[s2]==0.9.3",
+    "isodate==0.6.1"
+  ],
   "ssdp": [],
-  "version": "0.3.8",
+  "version": "0.3.9",
   "zeroconf": []
 }

--- a/custom_components/flexmeasures_hacs/models.py
+++ b/custom_components/flexmeasures_hacs/models.py
@@ -1,0 +1,51 @@
+"""Runtime data of a FlexMeasures config entry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from flexmeasures_client import FlexMeasuresClient
+from flexmeasures_client.s2.cem import CEM
+from homeassistant.config_entries import ConfigEntry
+
+from .control_types import FRBC_Config
+from .datastore import PersistentDatastore
+
+
+@dataclass
+class ScheduleState:
+    """The latest schedule fetched from FlexMeasures, as shown by the sensor."""
+
+    schedule: list[dict[str, Any]] = field(default_factory=list)
+    start: datetime | None = None
+    duration: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the state as the sensor's extra attributes."""
+        return {
+            "schedule": self.schedule,
+            "start": self.start,
+            "duration": self.duration,
+        }
+
+
+@dataclass
+class FlexMeasuresRuntimeData:
+    """Everything one config entry needs at runtime.
+
+    Kept on the config entry itself (entry.runtime_data) rather than in a
+    global hass.data[DOMAIN], so that several FlexMeasures servers can be
+    configured side by side.
+    """
+
+    client: FlexMeasuresClient
+    frbc_config: FRBC_Config
+    datastore: PersistentDatastore
+    timers: dict[str, datetime] = field(default_factory=dict)
+    schedule_state: ScheduleState = field(default_factory=ScheduleState)
+    cem: CEM | None = None
+
+
+type FlexMeasuresConfigEntry = ConfigEntry[FlexMeasuresRuntimeData]

--- a/custom_components/flexmeasures_hacs/sensor.py
+++ b/custom_components/flexmeasures_hacs/sensor.py
@@ -6,24 +6,26 @@ import logging
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, SCHEDULE_ENTITY, SCHEDULE_STATE, SIGNAL_UPDATE_SCHEDULE
+from .const import DOMAIN, SCHEDULE_ENTITY, signal_update_schedule
+from .models import FlexMeasuresConfigEntry
+from .services import get_from_option_or_config
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: FlexMeasuresConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor."""
-    hass.data[DOMAIN][SCHEDULE_STATE] = {"schedule": [], "start": None}
-
-    async_add_entities([FlexMeasuresScheduleSensor()], True)
+    async_add_entities([FlexMeasuresScheduleSensor(entry)])
 
 
 class FlexMeasuresScheduleSensor(SensorEntity):
@@ -31,39 +33,45 @@ class FlexMeasuresScheduleSensor(SensorEntity):
 
     _attr_device_class = SensorDeviceClass.POWER
     _attr_native_unit_of_measurement = UnitOfPower.KILO_WATT
+    _attr_has_entity_name = True
+    _attr_translation_key = "schedule"
+    _attr_should_poll = False
 
-    def __init__(self) -> None:
+    def __init__(self, entry: FlexMeasuresConfigEntry) -> None:
         """Sensor to store the schedule created by FlexMeasures."""
-        self._attr_unique_id = SCHEDULE_ENTITY
-
-    @property
-    def name(self) -> str:
-        """Sensor name."""
-        return "FlexMeasures Schedule"
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_{SCHEDULE_ENTITY}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            manufacturer="FlexMeasures",
+            name=entry.title,
+            configuration_url=get_from_option_or_config("url", entry),
+        )
 
     @property
     def native_value(self) -> float:
         """Average power."""
-
-        commands = self.hass.data[DOMAIN][SCHEDULE_STATE]["schedule"]
-        if len(commands) == 0:
+        commands = self._entry.runtime_data.schedule_state.schedule
+        if not commands:
             return 0
         return sum(command["value"] for command in commands) / len(commands)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return default attributes for the FlexMeasures Schedule sensor."""
-        return self.hass.data[DOMAIN][SCHEDULE_STATE]
+        return self._entry.runtime_data.schedule_state.as_dict()
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         self.async_on_remove(
             async_dispatcher_connect(
-                self.hass, SIGNAL_UPDATE_SCHEDULE, self._update_callback
+                self.hass,
+                signal_update_schedule(self._entry.entry_id),
+                self._update_callback,
             )
         )
 
     @callback
     def _update_callback(self) -> None:
         """Update the state."""
-        self.async_schedule_update_ha_state(True)
+        self.async_write_ha_state()

--- a/custom_components/flexmeasures_hacs/services.py
+++ b/custom_components/flexmeasures_hacs/services.py
@@ -1,263 +1,293 @@
-"""Services.."""
+"""Services of the FlexMeasures integration.
+
+Services are registered once for the integration, not per config entry. Each
+call resolves the config entry it acts on: implicitly when only one
+FlexMeasures server is configured, or explicitly through the `entry_id` field.
+Registering per entry used to re-register handlers bound to a stale entry on
+every options change (which reloads the entry).
+"""
+
+from __future__ import annotations
 
 from datetime import datetime
 import json
-import uuid
 import logging
 from typing import cast
-import pytz
+import uuid
 
 from flexmeasures_client import FlexMeasuresClient
 from flexmeasures_client.s2.cem import CEM
 from flexmeasures_client.s2.control_types.FRBC.frbc_tunes import (
     FillRateBasedControlTUNES,
 )
-from s2python.common import ControlType
-from s2python.frbc import FRBCInstruction
-import pandas as pd
-import voluptuous as vol
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
-    SupportsResponse,
     ServiceResponse,
+    SupportsResponse,
+    callback,
 )
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 import homeassistant.util.dt as dt_util
+import pandas as pd
+from s2python.common import ControlType
+from s2python.frbc import FRBCInstruction
+import voluptuous as vol
 
 from .const import (
+    ATTR_ENTRY_ID,
     DOMAIN,
-    FM_CLIENT,
     RESOLUTION,
-    SCHEDULE_STATE,
     SERVICE_CHANGE_CONTROL_TYPE,
-    SIGNAL_UPDATE_SCHEDULE,
     SOC_UNIT,
+    signal_update_schedule,
 )
 from .exception import UndefinedCEMError, UnknownControlType
-
-CHANGE_CONTROL_TYPE_SCHEMA = vol.Schema({vol.Optional("control_type"): str})
-
-SERVICES = [
-    {
-        "schema": CHANGE_CONTROL_TYPE_SCHEMA,
-        "service": SERVICE_CHANGE_CONTROL_TYPE,
-        "service_func_name": "change_control_type",
-    },
-    {
-        "schema": None,
-        "service": "trigger_and_get_schedule",
-        "service_func_name": "trigger_and_get_schedule",
-    },
-    {
-        "schema": None,
-        "service": "post_measurements",
-        "service_func_name": "post_measurements",
-    },
-    {
-        "schema": None,
-        "service": "send_frbc_instruction",
-        "service_func_name": "send_frbc_instruction",
-    },
-    {
-        "schema": None,
-        "service": "get_measurements",
-        "service_func_name": "get_measurements",
-        "supports_response": SupportsResponse.ONLY,
-    },
-    {
-        "schema": None,
-        "service": "call_cem_trigger_schedule",
-        "service_func_name": "call_cem_trigger_schedule",
-    },
-]
+from .models import FlexMeasuresConfigEntry
 
 LOGGER = logging.getLogger(__name__)
 
+ENTRY_ID_SCHEMA = {vol.Optional(ATTR_ENTRY_ID): str}
 
-async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Set up services."""
+CHANGE_CONTROL_TYPE_SCHEMA = vol.Schema(
+    {vol.Optional("control_type"): str, **ENTRY_ID_SCHEMA}
+)
 
-    ############
-    # Services #
-    ############
+SERVICE_TRIGGER_AND_GET_SCHEDULE = "trigger_and_get_schedule"
+SERVICE_POST_MEASUREMENTS = "post_measurements"
+SERVICE_SEND_FRBC_INSTRUCTION = "send_frbc_instruction"
+SERVICE_GET_MEASUREMENTS = "get_measurements"
+SERVICE_CALL_CEM_TRIGGER_SCHEDULE = "call_cem_trigger_schedule"
 
-    async def change_control_type(
-        call: ServiceCall,
-    ):  # pylint: disable=possibly-unused-variable
-        """Change control type S2 Protocol."""
+SERVICE_NAMES = (
+    SERVICE_CHANGE_CONTROL_TYPE,
+    SERVICE_TRIGGER_AND_GET_SCHEDULE,
+    SERVICE_POST_MEASUREMENTS,
+    SERVICE_SEND_FRBC_INSTRUCTION,
+    SERVICE_GET_MEASUREMENTS,
+    SERVICE_CALL_CEM_TRIGGER_SCHEDULE,
+)
 
-        if "cem" not in hass.data[DOMAIN]:
-            raise UndefinedCEMError()
 
-        cem: CEM = hass.data[DOMAIN]["cem"]
+@callback
+def _async_resolve_entry(
+    hass: HomeAssistant, call: ServiceCall
+) -> FlexMeasuresConfigEntry:
+    """Return the config entry a service call acts on."""
+    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+    entry_id = call.data.get(ATTR_ENTRY_ID)
 
-        control_type = cast(str, call.data.get("control_type"))
-
-        if not hasattr(ControlType, control_type):
-            raise UnknownControlType()
-
-        control_type = ControlType[control_type]
-
-        await cem.activate_control_type(control_type=control_type)
-
-        hass.states.async_set(
-            f"{DOMAIN}.cem", json.dumps({"control_type": str(cem.control_type)})
+    if entry_id is not None:
+        for entry in entries:
+            if entry.entry_id == entry_id:
+                return entry
+        raise ServiceValidationError(
+            f"No loaded FlexMeasures configuration entry with entry_id {entry_id!r}."
         )
 
-    async def trigger_and_get_schedule(
-        call: ServiceCall,
-    ):  # pylint: disable=possibly-unused-variable
-        client: FlexMeasuresClient = hass.data[DOMAIN][FM_CLIENT]
-        resolution = pd.Timedelta(RESOLUTION)
-        tzinfo = dt_util.get_time_zone(hass.config.time_zone)
-        start = time_ceil(datetime.now(tz=tzinfo), resolution)
-
-        flex_model = client.create_storage_flex_model(
-            soc_at_start=call.data.get("soc_at_start"),
-            soc_unit=SOC_UNIT,
-            soc_max=get_from_option_or_config("soc_max", entry),
-            soc_min=get_from_option_or_config("soc_min", entry),
-            soc_targets=call.data.get("soc_targets"),
-        )
-        flex_context = client.create_storage_flex_context(
-            consumption_price_sensor=get_from_option_or_config(
-                "consumption_price_sensor", entry
-            ),
-            production_price_sensor=get_from_option_or_config(
-                "production_price_sensor", entry
-            ),
+    if not entries:
+        raise ServiceValidationError("No FlexMeasures configuration entry is loaded.")
+    if len(entries) > 1:
+        raise ServiceValidationError(
+            "Several FlexMeasures configuration entries are loaded. "
+            f"Pass '{ATTR_ENTRY_ID}' to say which one this service call is for."
         )
 
-        flex_model.update(call.data.get("flex_model", {}))
-        flex_context.update(call.data.get("flex_context", {}))
+    return entries[0]
 
-        schedule_input = {
-            "sensor_id": get_from_option_or_config("power_sensor", entry),
-            "start": start,
-            "duration": get_from_option_or_config("schedule_duration", entry),
-            "flex_model": flex_model,
-            "flex_context": flex_context,
-        }
-        LOGGER.info(schedule_input)
-        schedule = await client.trigger_and_get_schedule(**schedule_input)
 
-        schedule["values"] = client.convert_units(
-            schedule["values"],
-            from_unit=schedule["unit"],
-            to_unit=UnitOfPower.KILO_WATT,
+@callback
+def _async_get_cem(entry: FlexMeasuresConfigEntry) -> CEM:
+    """Return the CEM of a config entry, which exists once an RM connected."""
+    cem = entry.runtime_data.cem
+    if cem is None:
+        raise UndefinedCEMError()
+    return cem
+
+
+async def change_control_type(call: ServiceCall) -> None:
+    """Change control type S2 Protocol."""
+    entry = _async_resolve_entry(call.hass, call)
+    cem = _async_get_cem(entry)
+
+    control_type = cast(str, call.data.get("control_type"))
+    if not hasattr(ControlType, control_type):
+        raise UnknownControlType()
+
+    await cem.activate_control_type(control_type=ControlType[control_type])
+
+    call.hass.states.async_set(
+        f"{DOMAIN}.cem", json.dumps({"control_type": str(cem.control_type)})
+    )
+
+
+async def trigger_and_get_schedule(call: ServiceCall) -> None:
+    """Trigger a schedule at FlexMeasures and store the result on the sensor."""
+    hass = call.hass
+    entry = _async_resolve_entry(hass, call)
+    runtime_data = entry.runtime_data
+    client: FlexMeasuresClient = runtime_data.client
+
+    resolution = pd.Timedelta(RESOLUTION)
+    tzinfo = dt_util.get_time_zone(hass.config.time_zone)
+    start = time_ceil(datetime.now(tz=tzinfo), resolution)
+
+    flex_model = client.create_storage_flex_model(
+        soc_at_start=call.data.get("soc_at_start"),
+        soc_unit=SOC_UNIT,
+        soc_max=get_from_option_or_config("soc_max", entry),
+        soc_min=get_from_option_or_config("soc_min", entry),
+        soc_targets=call.data.get("soc_targets"),
+    )
+    flex_context = client.create_storage_flex_context(
+        consumption_price_sensor=get_from_option_or_config(
+            "consumption_price_sensor", entry
+        ),
+        production_price_sensor=get_from_option_or_config(
+            "production_price_sensor", entry
+        ),
+    )
+
+    flex_model.update(call.data.get("flex_model", {}))
+    flex_context.update(call.data.get("flex_context", {}))
+
+    duration = get_from_option_or_config("schedule_duration", entry)
+    schedule_input = {
+        "sensor_id": get_from_option_or_config("power_sensor", entry),
+        "start": start,
+        "duration": duration,
+        "flex_model": flex_model,
+        "flex_context": flex_context,
+    }
+    LOGGER.debug("Triggering a schedule with %s", schedule_input)
+    schedule = await client.trigger_and_get_schedule(**schedule_input)
+
+    values = client.convert_units(
+        schedule["values"],
+        from_unit=schedule["unit"],
+        to_unit=UnitOfPower.KILO_WATT,
+    )
+
+    schedule_state = runtime_data.schedule_state
+    schedule_state.schedule = [
+        {"start": start + resolution * i, "value": value}
+        for i, value in enumerate(values)
+    ]
+    schedule_state.start = start
+    schedule_state.duration = duration
+
+    async_dispatcher_send(hass, signal_update_schedule(entry.entry_id))
+
+
+async def post_measurements(call: ServiceCall) -> None:
+    """Post measurements to FlexMeasures."""
+    entry = _async_resolve_entry(call.hass, call)
+
+    await entry.runtime_data.client.post_measurements(
+        sensor_id=call.data.get("sensor_id"),
+        start=call.data.get("start"),
+        duration=call.data.get("duration"),
+        values=call.data.get("values"),
+        unit=call.data.get("unit"),
+        prior=call.data.get("prior"),
+    )
+
+
+async def send_frbc_instruction(call: ServiceCall) -> None:
+    """Send an S2 Fill Rate Based Control message to the Resource Manager."""
+    hass = call.hass
+    entry = _async_resolve_entry(hass, call)
+    cem = _async_get_cem(entry)
+
+    dt_format = "%Y-%m-%d %H:%M:%S"
+    tzinfo = dt_util.get_time_zone(hass.config.time_zone)
+    execution_time = datetime.strptime(
+        call.data.get("execution_time", datetime.now(tz=tzinfo).strftime(dt_format)),
+        dt_format,
+    ).replace(tzinfo=tzinfo)
+
+    await cem.send_message(
+        FRBCInstruction(
+            id=call.data.get("id", uuid.uuid4()),
+            message_id=call.data.get("message_id", uuid.uuid4()),
+            actuator_id=call.data.get("actuator_id", uuid.uuid4()),
+            operation_mode=call.data.get("operation_mode", uuid.uuid4()),
+            operation_mode_factor=call.data.get("operation_mode_factor", 1.0),
+            execution_time=execution_time,
+            abnormal_condition=call.data.get("abnormal_condition", False),
         )
-        schedule = [
-            {"start": start + resolution * i, "value": value}
-            for i, value in enumerate(schedule["values"])
-        ]
+    )
 
-        hass.data[DOMAIN][SCHEDULE_STATE]["schedule"] = schedule
-        hass.data[DOMAIN][SCHEDULE_STATE]["start"] = start
-        hass.data[DOMAIN][SCHEDULE_STATE]["duration"] = get_from_option_or_config(
-            "schedule_duration", entry
+
+async def get_measurements(call: ServiceCall) -> ServiceResponse:
+    """Get sensor data from FlexMeasures."""
+    entry = _async_resolve_entry(call.hass, call)
+
+    data_query = {
+        "sensor_id": call.data.get("sensor_id"),
+        "start": call.data.get("start"),
+        "duration": call.data.get("duration"),
+        "unit": call.data.get("unit"),
+        "resolution": call.data.get("resolution"),
+    }
+    if "source" in call.data:
+        data_query["source"] = call.data["source"]
+
+    return await entry.runtime_data.client.get_sensor_data(**data_query)
+
+
+async def call_cem_trigger_schedule(call: ServiceCall) -> None:
+    """Let the CEM's FRBC handler trigger a schedule."""
+    entry = _async_resolve_entry(call.hass, call)
+    cem = _async_get_cem(entry)
+
+    if cem.control_type == ControlType.FILL_RATE_BASED_CONTROL:
+        frbc: FillRateBasedControlTUNES = cast(
+            FillRateBasedControlTUNES,
+            cem._control_types_handlers[ControlType.FILL_RATE_BASED_CONTROL],
         )
-
-        async_dispatcher_send(hass, SIGNAL_UPDATE_SCHEDULE)
-
-    async def post_measurements(
-        call: ServiceCall,
-    ):  # pylint: disable=possibly-unused-variable
-        client: FlexMeasuresClient = hass.data[DOMAIN][FM_CLIENT]
-
-        await client.post_measurements(
-            sensor_id=call.data.get("sensor_id"),
-            start=call.data.get("start"),
-            duration=call.data.get("duration"),
-            values=call.data.get("values"),
-            unit=call.data.get("unit"),
-            prior=call.data.get("prior"),
-        )
-
-    async def send_frbc_instruction(
-        call: ServiceCall,
-    ):  # pylint: disable=possibly-unused-variable
-        """Send S2 Fill Rate Based Control message to the ResourceManager"""
-
-        if "cem" not in hass.data[DOMAIN]:
-            raise UndefinedCEMError()
-
-        cem: CEM = hass.data[DOMAIN]["cem"]
-
-        tz = pytz.timezone(hass.config.time_zone)
-        DT_FMT = "%Y-%m-%d %H:%M:%S"
-        await cem.send_message(
-            FRBCInstruction(
-                id=call.data.get("id", uuid.uuid4()),
-                message_id=call.data.get("message_id", uuid.uuid4()),
-                actuator_id=call.data.get("actuator_id", uuid.uuid4()),
-                operation_mode=call.data.get("operation_mode", uuid.uuid4()),
-                operation_mode_factor=call.data.get("operation_mode_factor", 1.0),
-                execution_time=tz.localize(
-                    datetime.strptime(
-                        call.data.get(
-                            "execution_time", datetime.now().strftime(DT_FMT)
-                        ),
-                        DT_FMT,
-                    )
-                ),
-                abnormal_condition=call.data.get("abnormal_condition", False),
-            )
-        )
-
-    async def get_measurements(
-        call: ServiceCall,
-    ) -> ServiceResponse:  # pylint: disable=possibly-unused-variable
-        client: FlexMeasuresClient = hass.data[DOMAIN][FM_CLIENT]
-
-        data_query = dict(
-            sensor_id=call.data.get("sensor_id"),
-            start=call.data.get("start"),
-            duration=call.data.get("duration"),
-            unit=call.data.get("unit"),
-            resolution=call.data.get("resolution"),
-        )
-
-        if "source" in call.data:
-            data_query["source"] = call.data["source"]
-
-        response = await client.get_sensor_data(**data_query)
-
-        return response
-
-    async def call_cem_trigger_schedule(call: ServiceCall):
-        if "cem" not in hass.data[DOMAIN]:
-            raise UndefinedCEMError()
-
-        cem: CEM = hass.data[DOMAIN]["cem"]
-
-        if cem.control_type == ControlType.FILL_RATE_BASED_CONTROL:
-            frbc: FillRateBasedControlTUNES = cast(
-                FillRateBasedControlTUNES,
-                cem._control_types_handlers[ControlType.FILL_RATE_BASED_CONTROL],
-            )
-            await frbc.trigger_schedule()
-
-    #####################
-    # Register services #
-    #####################
-
-    for service in SERVICES:
-        if "service_func_name" in service:
-            service_func_name = service.pop("service_func_name")
-            service["service_func"] = locals()[service_func_name]
-
-        hass.services.async_register(DOMAIN, **service)
+        await frbc.trigger_schedule()
 
 
-async def async_unload_services(hass: HomeAssistant) -> None:
-    """Unload services."""
-    for service in SERVICES:
-        if hass.services.has_service(DOMAIN, service["service"]):
-            hass.services.async_remove(DOMAIN, service["service"])
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the services, once for the whole integration."""
+    if hass.services.has_service(DOMAIN, SERVICE_CHANGE_CONTROL_TYPE):
+        return
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CHANGE_CONTROL_TYPE,
+        change_control_type,
+        schema=CHANGE_CONTROL_TYPE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_TRIGGER_AND_GET_SCHEDULE, trigger_and_get_schedule
+    )
+    hass.services.async_register(DOMAIN, SERVICE_POST_MEASUREMENTS, post_measurements)
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_FRBC_INSTRUCTION, send_frbc_instruction
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_MEASUREMENTS,
+        get_measurements,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CALL_CEM_TRIGGER_SCHEDULE, call_cem_trigger_schedule
+    )
+
+
+@callback
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Remove the services."""
+    for service_name in SERVICE_NAMES:
+        if hass.services.has_service(DOMAIN, service_name):
+            hass.services.async_remove(DOMAIN, service_name)
 
 
 def time_mod(time, delta, epoch=None):

--- a/custom_components/flexmeasures_hacs/services.yaml
+++ b/custom_components/flexmeasures_hacs/services.yaml
@@ -1,3 +1,5 @@
+# Every service takes an optional entry_id, needed only when more than one
+# FlexMeasures server is configured. With a single one, it is used implicitly.
 change_control_type:
   fields:
     control_type:
@@ -8,6 +10,11 @@ change_control_type:
           options:
             - "NO_SELECTION"
             - "FILL_RATE_BASED_CONTROL"
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs
 trigger_and_get_schedule:
   fields:
     soc_at_start:
@@ -22,6 +29,42 @@ trigger_and_get_schedule:
       required: false
       selector:
         object:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs
+post_measurements:
+  fields:
+    sensor_id:
+      required: true
+      selector:
+        number:
+    start:
+      required: true
+      selector:
+        datetime:
+    duration:
+      required: true
+      selector:
+        text:
+    values:
+      required: true
+      selector:
+        object:
+    unit:
+      required: true
+      selector:
+        text:
+    prior:
+      required: false
+      selector:
+        datetime:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs
 send_frbc_instruction:
   fields:
     id:
@@ -58,6 +101,11 @@ send_frbc_instruction:
       default: false
       selector:
         boolean:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs
 get_measurements:
   fields:
     sensor_id:
@@ -79,8 +127,20 @@ get_measurements:
     resolution:
       required: false
       selector:
-        text:  
+        text:
     source:
       required: false
       selector:
         number:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs
+call_cem_trigger_schedule:
+  fields:
+    entry_id:
+      required: false
+      selector:
+        config_entry:
+          integration: flexmeasures_hacs

--- a/custom_components/flexmeasures_hacs/strings.json
+++ b/custom_components/flexmeasures_hacs/strings.json
@@ -195,6 +195,9 @@
     "sensor": {
       "power": {
         "name": "FlexMeasures power sensor"
+      },
+      "schedule": {
+        "name": "Schedule"
       }
     }
   }

--- a/custom_components/flexmeasures_hacs/translations/en.json
+++ b/custom_components/flexmeasures_hacs/translations/en.json
@@ -1,360 +1,362 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_email": "Invalid email",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "reauth_confirm": {
+        "data": {
+          "consumption_price_sensor": "Consumption price sensor",
+          "host": "Host",
+          "password": "Password",
+          "power_sensor": "Power sensor",
+          "production_price_sensor": "Production price sensor",
+          "schedule_duration": "Schedule Duration",
+          "soc_max": "Maximum SOC",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "Minimum SOC",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "SOC unit",
+          "username": "Username"
         },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "invalid_email": "Invalid email",
-            "unknown": "Unexpected error"
+        "data_description": {
+          "consumption_price_sensor": "The sensor that provides the consumption price data.",
+          "host": "The URL of the FlexMeasures instance.",
+          "password": "The password to log in to the FlexMeasures instance.",
+          "power_sensor": "The sensor that provides the power data.",
+          "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
+          "schedule_duration": "The duration of the schedule in minutes.",
+          "soc_max": "The maximum state of charge.",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "The minimum state of charge.",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "The unit of the state of charge.",
+          "username": "The email to log in to the FlexMeasures instance."
         },
-        "step": {
-            "reauth_confirm": {
-                "data": {
-                    "consumption_price_sensor": "Consumption price sensor",
-                    "host": "Host",
-                    "password": "Password",
-                    "power_sensor": "Power sensor",
-                    "production_price_sensor": "Production price sensor",
-                    "schedule_duration": "Schedule Duration",
-                    "soc_max": "Maximum SOC",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "Minimum SOC",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "SOC unit",
-                    "username": "Username"
-                },
-                "data_description": {
-                    "consumption_price_sensor": "The sensor that provides the consumption price data.",
-                    "host": "The URL of the FlexMeasures instance.",
-                    "password": "The password to log in to the FlexMeasures instance.",
-                    "power_sensor": "The sensor that provides the power data.",
-                    "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
-                    "schedule_duration": "The duration of the schedule in minutes.",
-                    "soc_max": "The maximum state of charge.",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "The minimum state of charge.",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "The unit of the state of charge.",
-                    "username": "The email to log in to the FlexMeasures instance."
-                },
-                "sections": {
-                  "s2": {
-                      "name": "S2",
-                      "description": "Optional parameters to interface to a S2 resource manager",
-                      "data": {
-                        "consumption_sensor_id": "consumption_sensor_id",
-                        "fill_level_sensor_id": "fill_level_sensor_id",
-                        "fill_rate_sensor_id": "fill_rate_sensor_id",
-                        "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                        "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                        "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                        "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                        "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                        "rm_discharge_sensor": "Resource Manager Discharge Sensor",
-                        "leakage_behaviour_sensor_id" : "leakage_behaviour_sensor_id",
-                        "state_of_charge_sensor_id" : "state_of_charge_sensor_id"
-                      },
-                      "data_description": {
-                        "consumption_sensor_id": "Sensor ID to record power consumption.",
-                        "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
-                        "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
-                        "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
-                        "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
-                        "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
-                        "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
-                        "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
-                        "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
-                        "leakage_behaviour_sensor_id" : "Sensor ID to record the leakage behaviour.",
-                        "state_of_charge_sensor_id" : "Sensor ID to record the State of Charge of the planned schedule."
-                      }
-                  }
-                }
+        "sections": {
+          "s2": {
+            "name": "S2",
+            "description": "Optional parameters to interface to a S2 resource manager",
+            "data": {
+              "consumption_sensor_id": "consumption_sensor_id",
+              "fill_level_sensor_id": "fill_level_sensor_id",
+              "fill_rate_sensor_id": "fill_rate_sensor_id",
+              "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+              "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+              "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+              "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+              "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+              "rm_discharge_sensor": "Resource Manager Discharge Sensor",
+              "leakage_behaviour_sensor_id": "leakage_behaviour_sensor_id",
+              "state_of_charge_sensor_id": "state_of_charge_sensor_id"
             },
-            "user": {
-                "data": {
-                    "consumption_sensor_id": "consumption_sensor_id",
-                    "consumption_price_sensor": "Consumption price sensor",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "host": "Host",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "password": "Password",
-                    "power_sensor": "Power sensor",
-                    "production_price_sensor": "Production price sensor",
-                    "rm_discharge_sensor": "Resource Manager Discharge Sensor",
-                    "schedule_duration": "Schedule Duration",
-                    "soc_max": "Maximum SOC",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "Minimum SOC",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "SOC unit",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "username": "Username"
-                },
-                "data_description": {
-                    "consumption_sensor_id": "The sensor that records the power consumption.",
-                    "consumption_price_sensor": "The sensor that provides the consumption price data.",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "host": "The URL of the FlexMeasures instance.",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "password": "The password to log in to the FlexMeasures instance.",
-                    "power_sensor": "The sensor that provides the power data.",
-                    "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
-                    "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
-                    "schedule_duration": "The duration of the schedule in minutes.",
-                    "soc_max": "The maximum state of charge.",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "The minimum state of charge.",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "The unit of the state of charge.",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "username": "The email to log in to the FlexMeasures instance."
-                },
-                "sections": {
-              "s2": {
-                  "name": "S2",
-                  "description": "Optional parameters to interface to a S2 resource manager",
-                  "data": {
-                    "consumption_sensor_id": "consumption_sensor_id",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "rm_discharge_sensor": "Resource Manager Discharge Sensor",
-                    "leakage_behaviour_sensor_id" : "leakage_behaviour_sensor_id",
-                    "state_of_charge_sensor_id" : "state_of_charge_sensor_id"
-                  },
-                  "data_description": {
-                    "consumption_sensor_id": "Sensor ID to record power consumption.",
-                    "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
-                    "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
-                    "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
-                    "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
-                    "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
-                    "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
-                    "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
-                    "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
-                    "leakage_behaviour_sensor_id" : "Sensor ID to record the leakage behaviour.",
-                    "state_of_charge_sensor_id" : "Sensor ID to record the State of Charge of the planned schedule."
-                  }
-              }
+            "data_description": {
+              "consumption_sensor_id": "Sensor ID to record power consumption.",
+              "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
+              "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
+              "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
+              "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
+              "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
+              "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
+              "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
+              "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
+              "leakage_behaviour_sensor_id": "Sensor ID to record the leakage behaviour.",
+              "state_of_charge_sensor_id": "Sensor ID to record the State of Charge of the planned schedule."
+            }
           }
-            }
         }
-    },
-    "entity": {
-        "sensor": {
-            "power": {
-                "name": "FlexMeasures power sensor"
+      },
+      "user": {
+        "data": {
+          "consumption_sensor_id": "consumption_sensor_id",
+          "consumption_price_sensor": "Consumption price sensor",
+          "fill_level_sensor_id": "fill_level_sensor_id",
+          "fill_rate_sensor_id": "fill_rate_sensor_id",
+          "host": "Host",
+          "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+          "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+          "password": "Password",
+          "power_sensor": "Power sensor",
+          "production_price_sensor": "Production price sensor",
+          "rm_discharge_sensor": "Resource Manager Discharge Sensor",
+          "schedule_duration": "Schedule Duration",
+          "soc_max": "Maximum SOC",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "Minimum SOC",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "SOC unit",
+          "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+          "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+          "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+          "username": "Username"
+        },
+        "data_description": {
+          "consumption_sensor_id": "The sensor that records the power consumption.",
+          "consumption_price_sensor": "The sensor that provides the consumption price data.",
+          "fill_level_sensor_id": "fill_level_sensor_id",
+          "fill_rate_sensor_id": "fill_rate_sensor_id",
+          "host": "The URL of the FlexMeasures instance.",
+          "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+          "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+          "password": "The password to log in to the FlexMeasures instance.",
+          "power_sensor": "The sensor that provides the power data.",
+          "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
+          "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
+          "schedule_duration": "The duration of the schedule in minutes.",
+          "soc_max": "The maximum state of charge.",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "The minimum state of charge.",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "The unit of the state of charge.",
+          "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+          "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+          "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+          "username": "The email to log in to the FlexMeasures instance."
+        },
+        "sections": {
+          "s2": {
+            "name": "S2",
+            "description": "Optional parameters to interface to a S2 resource manager",
+            "data": {
+              "consumption_sensor_id": "consumption_sensor_id",
+              "fill_level_sensor_id": "fill_level_sensor_id",
+              "fill_rate_sensor_id": "fill_rate_sensor_id",
+              "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+              "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+              "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+              "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+              "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+              "rm_discharge_sensor": "Resource Manager Discharge Sensor",
+              "leakage_behaviour_sensor_id": "leakage_behaviour_sensor_id",
+              "state_of_charge_sensor_id": "state_of_charge_sensor_id"
+            },
+            "data_description": {
+              "consumption_sensor_id": "Sensor ID to record power consumption.",
+              "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
+              "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
+              "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
+              "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
+              "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
+              "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
+              "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
+              "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
+              "leakage_behaviour_sensor_id": "Sensor ID to record the leakage behaviour.",
+              "state_of_charge_sensor_id": "Sensor ID to record the State of Charge of the planned schedule."
             }
-        }
-    },
-    "options": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "invalid_email": "Invalid email",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "init": {
-                "data": {
-                    "consumption_sensor_id": "consumption_sensor_id",
-                    "consumption_price_sensor": "Consumption price sensor",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "host": "Host",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "password": "Password",
-                    "power_sensor": "Power sensor",
-                    "production_price_sensor": "Production price sensor",
-                    "rm_discharge_sensor": "Resource Manager Discharge Sensor",
-                    "schedule_duration": "Schedule Duration",
-                    "soc_max": "Maximum SOC",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "Minimum SOC",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "SOC unit",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "active_actuator_id_sensor_id" : "active_actuator_id_sensor_id",
-                    "username": "Username"
-                },
-                "data_description": {
-                    "consumption_sensor_id": "consumption_sensor_id",
-                    "consumption_price_sensor": "The sensor that provides the consumption price data.",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "host": "The URL of the FlexMeasures instance.",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "password": "The password to log in to the FlexMeasures instance.",
-                    "power_sensor": "The sensor that provides the power data.",
-                    "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
-                    "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
-                    "schedule_duration": "The duration of the schedule in minutes.",
-                    "soc_max": "The maximum state of charge.",
-                    "soc_maxima_sensor_id": "soc_maxima_sensor_id",
-                    "soc_min": "The minimum state of charge.",
-                    "soc_minima_sensor_id": "soc_minima_sensor_id",
-                    "soc_unit": "The unit of the state of charge.",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "active_actuator_id_sensor_id" : "Sensor ID to record which actuator is active.",
-                    "username": "The email to log in to the FlexMeasures instance."
-                },
-                "sections": {
-              "s2": {
-                  "name": "S2",
-                  "description": "Optional parameters to interface to a S2 resource manager",
-                  "data": {
-                    "consumption_sensor_id": "consumption_sensor_id",
-                    "fill_level_sensor_id": "fill_level_sensor_id",
-                    "fill_rate_sensor_id": "fill_rate_sensor_id",
-                    "usage_forecast_sensor_id": "usage_forecast_sensor_id",
-                    "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
-                    "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
-                    "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
-                    "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
-                    "rm_discharge_sensor": "Resource Manager Discharge Sensor",
-                    "active_actuator_id_sensor_id" : "active_actuator_id_sensor_id",
-                    "leakage_behaviour_sensor_id" : "leakage_behaviour_sensor_id",
-                    "state_of_charge_sensor_id" : "state_of_charge_sensor_id"
-                  },
-                  "data_description": {
-                    "consumption_sensor_id": "Sensor ID to record power consumption",
-                    "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
-                    "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
-                    "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
-                    "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
-                    "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
-                    "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
-                    "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
-                    "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
-                    "active_actuator_id_sensor_id" : "Sensor ID to record which actuator is active.",
-                    "leakage_behaviour_sensor_id" : "Sensor ID to record the leakage behaviour.",
-                    "state_of_charge_sensor_id" : "Sensor ID to record the State of Charge of the planned schedule."
-                  }
-              }
           }
-
-            }
         }
-    },
-    "services": {
-        "call_cem_trigger_schedule" : {
-            "description" : "Call CEM Trigger Schedule",
-            "name" : "Call CEM Trigger schedule"
-        },
-        "change_control_type": {
-            "description": "Change the CEM control type.",
-            "fields": {
-                "control_type": {
-                    "description": "CEM control type.",
-                    "name": "Control Type"
-                }
-            },
-            "name": "Change Control Type"
-        },
-        "trigger_and_get_schedule": {
-            "description": "Trigger a schedule in FlexMeasures and get the results back.",
-            "fields": {
-                "soc_at_start": {
-                    "description": "Initial state of charge of the energy storage.",
-                    "name": "Initial SOC"
-                },
-                "flex_model" : {
-                    "description" : "Device flexibility model.",
-                    "name" : "Flex Model"
-                },
-                "flex_context" : {
-                    "description" : "Device flexibility context.",
-                    "name" : "Flex Context"
-                }
-            },
-            "name": "Trigger and get schedule"
-        },
-        "send_frbc_instruction": {
-        "description": "Send an FRBC instruction.",
-        "fields": {
-            "id": {
-                "description": "Unique identifier for the instruction.",
-                "name": "ID"
-            },
-            "message_id": {
-                "description": "Message identifier.",
-                "name": "Message ID"
-            },
-            "actuator_id": {
-                "description": "Actuator identifier.",
-                "name": "Actuator ID"
-            },
-            "operation_mode": {
-                "description": "Operation mode for the actuator.",
-                "name": "Operation Mode"
-            },
-            "operation_mode_factor": {
-                "description": "Factor for the operation mode, ranging from 0 to 1.",
-                "name": "Operation Mode Factor"
-            },
-            "execution_time": {
-                "description": "Time at which the instruction should be executed.",
-                "name": "Execution Time"
-            },
-            "abnormal_condition": {
-                "description": "Whether the FRBC Instruction is abnormal or normal. Default: normal.",
-                "name": "Abnormal Condition"
-            }
-        },
-        "name": "Send FRBC Instruction"
-        },
-        "get_measurements": {
-            "name" : "Get Measurements",
-            "description": "Retrieve measurements from a specific sensor",
-            "fields": {
-                "sensor_id": {
-                    "description": "Unique identifier for the sensor.",
-                    "name": "Sensor ID"
-                },
-                "start": {
-                    "description": "Start time of the measurement request.",
-                    "name": "Start"
-                },
-                "duration": {
-                    "description": "Duration of the measurement request, specifying how long data should be retrieved for.",
-                    "name": "Duration"
-                },
-                "unit": {
-                    "description": "Unit of measurement for the data (e.g., kW, MW, etc.).",
-                    "name": "Unit"
-                },
-                "resolution": {
-                    "description": "Resolution for the data in ISO 8601 format (e.g., PT15M, P1H, etc.).",
-                    "name": "Resolution"
-                },
-                "source": {
-                    "description": "Filter the data by Source ID.",
-                    "name": "Source"
-                }
-            }
-        }
+      }
     }
+  },
+  "entity": {
+    "sensor": {
+      "power": {
+        "name": "FlexMeasures power sensor"
+      },
+      "schedule": {
+        "name": "Schedule"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "Device is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_email": "Invalid email",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "consumption_sensor_id": "consumption_sensor_id",
+          "consumption_price_sensor": "Consumption price sensor",
+          "fill_level_sensor_id": "fill_level_sensor_id",
+          "fill_rate_sensor_id": "fill_rate_sensor_id",
+          "host": "Host",
+          "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+          "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+          "password": "Password",
+          "power_sensor": "Power sensor",
+          "production_price_sensor": "Production price sensor",
+          "rm_discharge_sensor": "Resource Manager Discharge Sensor",
+          "schedule_duration": "Schedule Duration",
+          "soc_max": "Maximum SOC",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "Minimum SOC",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "SOC unit",
+          "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+          "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+          "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+          "active_actuator_id_sensor_id": "active_actuator_id_sensor_id",
+          "username": "Username"
+        },
+        "data_description": {
+          "consumption_sensor_id": "consumption_sensor_id",
+          "consumption_price_sensor": "The sensor that provides the consumption price data.",
+          "fill_level_sensor_id": "fill_level_sensor_id",
+          "fill_rate_sensor_id": "fill_rate_sensor_id",
+          "host": "The URL of the FlexMeasures instance.",
+          "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+          "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+          "password": "The password to log in to the FlexMeasures instance.",
+          "power_sensor": "The sensor that provides the power data.",
+          "production_price_sensor": "The sensor that provides the production price data. Can be the same as the consumption price sensor.",
+          "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
+          "schedule_duration": "The duration of the schedule in minutes.",
+          "soc_max": "The maximum state of charge.",
+          "soc_maxima_sensor_id": "soc_maxima_sensor_id",
+          "soc_min": "The minimum state of charge.",
+          "soc_minima_sensor_id": "soc_minima_sensor_id",
+          "soc_unit": "The unit of the state of charge.",
+          "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+          "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+          "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+          "active_actuator_id_sensor_id": "Sensor ID to record which actuator is active.",
+          "username": "The email to log in to the FlexMeasures instance."
+        },
+        "sections": {
+          "s2": {
+            "name": "S2",
+            "description": "Optional parameters to interface to a S2 resource manager",
+            "data": {
+              "consumption_sensor_id": "consumption_sensor_id",
+              "fill_level_sensor_id": "fill_level_sensor_id",
+              "fill_rate_sensor_id": "fill_rate_sensor_id",
+              "usage_forecast_sensor_id": "usage_forecast_sensor_id",
+              "thp_fill_rate_sensor_id": "thp_fill_rate_sensor_id",
+              "thp_efficiency_sensor_id": "thp_efficiency_sensor_id",
+              "nes_fill_rate_sensor_id": "nes_fill_rate_sensor_id",
+              "nes_efficiency_sensor_id": "nes_efficiency_sensor_id",
+              "rm_discharge_sensor": "Resource Manager Discharge Sensor",
+              "active_actuator_id_sensor_id": "active_actuator_id_sensor_id",
+              "leakage_behaviour_sensor_id": "leakage_behaviour_sensor_id",
+              "state_of_charge_sensor_id": "state_of_charge_sensor_id"
+            },
+            "data_description": {
+              "consumption_sensor_id": "Sensor ID to record power consumption",
+              "fill_level_sensor_id": "Fill level sensor ID of the NES heat storage.",
+              "fill_rate_sensor_id": "Fill rate sensor ID of the active actuator (THP or NES internal resitor).",
+              "usage_forecast_sensor_id": "Usage Forecast sensor ID.",
+              "thp_fill_rate_sensor_id": "Fill rate sensor ID of the Tarnoc Heat Pump.",
+              "thp_efficiency_sensor_id": "Tarnoc heat pump coefficient of performance (Thermal Power / Electrical Power).",
+              "nes_fill_rate_sensor_id": "Fill rate sensor ID of the Nestore hot water storage internal thermal resistor.",
+              "nes_efficiency_sensor_id": "Nestore internal resistor coefficient of performance (Thermal Power / Electrical Power).",
+              "rm_discharge_sensor": "The sensor that provides the resource manager discharge data.",
+              "active_actuator_id_sensor_id": "Sensor ID to record which actuator is active.",
+              "leakage_behaviour_sensor_id": "Sensor ID to record the leakage behaviour.",
+              "state_of_charge_sensor_id": "Sensor ID to record the State of Charge of the planned schedule."
+            }
+          }
+        }
+      }
+    }
+  },
+  "services": {
+    "call_cem_trigger_schedule": {
+      "description": "Call CEM Trigger Schedule",
+      "name": "Call CEM Trigger schedule"
+    },
+    "change_control_type": {
+      "description": "Change the CEM control type.",
+      "fields": {
+        "control_type": {
+          "description": "CEM control type.",
+          "name": "Control Type"
+        }
+      },
+      "name": "Change Control Type"
+    },
+    "trigger_and_get_schedule": {
+      "description": "Trigger a schedule in FlexMeasures and get the results back.",
+      "fields": {
+        "soc_at_start": {
+          "description": "Initial state of charge of the energy storage.",
+          "name": "Initial SOC"
+        },
+        "flex_model": {
+          "description": "Device flexibility model.",
+          "name": "Flex Model"
+        },
+        "flex_context": {
+          "description": "Device flexibility context.",
+          "name": "Flex Context"
+        }
+      },
+      "name": "Trigger and get schedule"
+    },
+    "send_frbc_instruction": {
+      "description": "Send an FRBC instruction.",
+      "fields": {
+        "id": {
+          "description": "Unique identifier for the instruction.",
+          "name": "ID"
+        },
+        "message_id": {
+          "description": "Message identifier.",
+          "name": "Message ID"
+        },
+        "actuator_id": {
+          "description": "Actuator identifier.",
+          "name": "Actuator ID"
+        },
+        "operation_mode": {
+          "description": "Operation mode for the actuator.",
+          "name": "Operation Mode"
+        },
+        "operation_mode_factor": {
+          "description": "Factor for the operation mode, ranging from 0 to 1.",
+          "name": "Operation Mode Factor"
+        },
+        "execution_time": {
+          "description": "Time at which the instruction should be executed.",
+          "name": "Execution Time"
+        },
+        "abnormal_condition": {
+          "description": "Whether the FRBC Instruction is abnormal or normal. Default: normal.",
+          "name": "Abnormal Condition"
+        }
+      },
+      "name": "Send FRBC Instruction"
+    },
+    "get_measurements": {
+      "name": "Get Measurements",
+      "description": "Retrieve measurements from a specific sensor",
+      "fields": {
+        "sensor_id": {
+          "description": "Unique identifier for the sensor.",
+          "name": "Sensor ID"
+        },
+        "start": {
+          "description": "Start time of the measurement request.",
+          "name": "Start"
+        },
+        "duration": {
+          "description": "Duration of the measurement request, specifying how long data should be retrieved for.",
+          "name": "Duration"
+        },
+        "unit": {
+          "description": "Unit of measurement for the data (e.g., kW, MW, etc.).",
+          "name": "Unit"
+        },
+        "resolution": {
+          "description": "Resolution for the data in ISO 8601 format (e.g., PT15M, P1H, etc.).",
+          "name": "Resolution"
+        },
+        "source": {
+          "description": "Filter the data by Source ID.",
+          "name": "Source"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/flexmeasures_hacs/websockets.py
+++ b/custom_components/flexmeasures_hacs/websockets.py
@@ -77,7 +77,6 @@ class WebSocketHandler:
 
         self._logger = WebSocketAdapter(_WS_LOGGER, {"connid": id(self)})
         self._logger.debug("new websockets connection")
-        self._logger.warning(hass.data[DOMAIN][FM_CLIENT])
 
         frbc_data: FRBC_Config = hass.data[DOMAIN][FRBC_CONFIG]
         self._logger.info(

--- a/custom_components/flexmeasures_hacs/websockets.py
+++ b/custom_components/flexmeasures_hacs/websockets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import asdict
 import logging
-from typing import Any, Final
+from typing import Any, ClassVar, Final
 
 import aiohttp
 from aiohttp import web
@@ -14,23 +14,34 @@ from flexmeasures_client.s2.control_types.FRBC.frbc_tunes import (
     FillRateBasedControlTUNES,
 )
 from flexmeasures_client.s2.utils import get_unique_id
-from s2python.common import EnergyManagementRole, Handshake, ControlType
-
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.http import KEY_HASS
+from s2python.common import ControlType, EnergyManagementRole, Handshake
 
-from .const import (
-    DATASTORE,
-    DOMAIN,
-    FM_CLIENT,
-    FRBC_CONFIG,
-    TIMERS,
-    WS_VIEW_NAME,
-    WS_VIEW_URI,
-)
+from .const import DOMAIN, WS_VIEW_NAME, WS_VIEW_URI
 from .control_types import FRBC_Config
+from .models import FlexMeasuresConfigEntry
 
 _WS_LOGGER: Final = logging.getLogger(f"{__name__}.connection")
+
+DATA_VIEW_REGISTERED: Final = f"{DOMAIN}_websocket_view_registered"
+
+
+@callback
+def async_register_websocket_view(hass: HomeAssistant) -> None:
+    """Register the S2 websocket view, once for the whole integration.
+
+    A view is registered on Home Assistant's HTTP app, not on a config entry,
+    so it must not be registered again per entry. Resource Managers pick the
+    config entry to talk to by connecting to /api/websocket_custom/<entry_id>;
+    the bare /api/websocket_custom is served when only one entry is loaded.
+    """
+    if hass.data.get(DATA_VIEW_REGISTERED):
+        return
+
+    hass.http.register_view(WebsocketAPIView())
+    hass.data[DATA_VIEW_REGISTERED] = True
 
 
 class WebsocketAPIView(HomeAssistantView):
@@ -38,19 +49,57 @@ class WebsocketAPIView(HomeAssistantView):
 
     name: str = WS_VIEW_NAME
     url: str = WS_VIEW_URI
+    extra_urls: ClassVar[list[str]] = [f"{WS_VIEW_URI}/{{entry_id}}"]
     requires_auth: bool = False
 
-    def __init__(self, entry) -> None:
-        """Initialize websocket view."""
-        super().__init__()
-        self.entry = entry
-
-    async def get(self, request: web.Request) -> web.WebSocketResponse:
+    async def get(
+        self, request: web.Request, entry_id: str | None = None
+    ) -> web.WebSocketResponse:
         """Handle an incoming websocket connection."""
+        hass = request.app[KEY_HASS]
+        entry = _async_resolve_entry(hass, entry_id)
 
-        return await WebSocketHandler(
-            request.app["hass"], self.entry, request
-        ).async_handle()
+        if entry.runtime_data.frbc_config.asset_id is None:
+            # Better to say so than to run the S2 control path against sensor
+            # ids that are not set (earlier versions silently fell back to the
+            # ids of one pilot's FlexMeasures server).
+            raise web.HTTPBadRequest(
+                text=(
+                    "The S2 section of the FlexMeasures configuration is incomplete: "
+                    "set at least the asset_id, in Settings > Devices & services > "
+                    "FlexMeasures > Configure."
+                )
+            )
+
+        return await WebSocketHandler(hass, entry, request).async_handle()
+
+
+@callback
+def _async_resolve_entry(
+    hass: HomeAssistant, entry_id: str | None
+) -> FlexMeasuresConfigEntry:
+    """Return the config entry a websocket connection is for."""
+    entries = hass.config_entries.async_loaded_entries(DOMAIN)
+
+    if entry_id is not None:
+        for entry in entries:
+            if entry.entry_id == entry_id:
+                return entry
+        raise web.HTTPNotFound(
+            text=f"No loaded FlexMeasures configuration entry with entry_id {entry_id!r}."
+        )
+
+    if not entries:
+        raise web.HTTPNotFound(text="No FlexMeasures configuration entry is loaded.")
+    if len(entries) > 1:
+        raise web.HTTPBadRequest(
+            text=(
+                "Several FlexMeasures configuration entries are loaded. "
+                f"Connect to {WS_VIEW_URI}/<entry_id> to say which one to use."
+            )
+        )
+
+    return entries[0]
 
 
 class WebSocketAdapter(logging.LoggerAdapter):
@@ -60,7 +109,7 @@ class WebSocketAdapter(logging.LoggerAdapter):
         """Add connid to websocket log messages."""
         if not self.extra or "connid" not in self.extra:
             return msg, kwargs
-        return f'[{self.extra["connid"]}] {msg}', kwargs
+        return f"[{self.extra['connid']}] {msg}", kwargs
 
 
 class WebSocketHandler:
@@ -68,7 +117,12 @@ class WebSocketHandler:
 
     cem: CEM
 
-    def __init__(self, hass: HomeAssistant, entry, request: web.Request) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: FlexMeasuresConfigEntry,
+        request: web.Request,
+    ) -> None:
         """Initialize an active connection."""
         self.hass = hass
         self.request = request
@@ -78,16 +132,18 @@ class WebSocketHandler:
         self._logger = WebSocketAdapter(_WS_LOGGER, {"connid": id(self)})
         self._logger.debug("new websockets connection")
 
-        frbc_data: FRBC_Config = hass.data[DOMAIN][FRBC_CONFIG]
+        runtime_data = entry.runtime_data
+        frbc_data: FRBC_Config = runtime_data.frbc_config
         self._logger.info(
-            f"Resource in FRBC mode mapped to FlexMeasures asset {frbc_data.asset_id}."
+            "Resource in FRBC mode mapped to FlexMeasures asset %s.", frbc_data.asset_id
         )
+
         self.cem = CEM(
-            fm_client=hass.data[DOMAIN][FM_CLIENT],
+            fm_client=runtime_data.client,
             default_control_type=ControlType.FILL_RATE_BASED_CONTROL,
             logger=_WS_LOGGER,
-            timers=hass.data[DOMAIN][TIMERS],
-            datastore=hass.data[DOMAIN][DATASTORE],
+            timers=runtime_data.timers,
+            datastore=runtime_data.datastore,
             power_sensor_id={
                 # todo: set up the other power sensors
                 # "ELECTRIC.POWER.3_PHASE_SYMMETRIC": frbc_data.<id>,  # THP
@@ -99,12 +155,12 @@ class WebSocketHandler:
         )
         frbc = FillRateBasedControlTUNES(
             **asdict(frbc_data),
-            timers=hass.data[DOMAIN][TIMERS],
-            datastore=hass.data[DOMAIN][DATASTORE],
+            timers=runtime_data.timers,
+            datastore=runtime_data.datastore,
             timezone=hass.config.time_zone,
         )
-        hass.data[DOMAIN]["cem"] = self.cem
         self.cem.register_control_type(frbc)
+        runtime_data.cem = self.cem
 
     async def _websocket_producer(self):
         """Send the messages available at the `cem` queue."""
@@ -152,8 +208,18 @@ class WebSocketHandler:
                         "Msg.type == aiohttp.WSMsgType.ERROR: closing CEM.."
                     )
                     await cem.close()
-        except Exception:  # pylint: disable=broad-exception-caught
+        except ConnectionError:
+            # Only a failure to reach FlexMeasures says anything about our
+            # credentials. Any other error here is a bug in handling the
+            # message, and asking the user to re-authenticate would only
+            # obscure it.
+            self._logger.warning(
+                "Cannot reach FlexMeasures; asking for re-authentication",
+                exc_info=True,
+            )
             self.entry.async_start_reauth(self.hass)
+        except Exception:  # pylint: disable=broad-exception-caught
+            self._logger.exception("Error while handling an incoming S2 message")
         finally:
             self._logger.debug("Finished _websocket_consumer: closing CEM..")
             await cem.close()
@@ -176,6 +242,5 @@ class WebSocketHandler:
         except ConnectionResetError:
             self._logger.debug("Connection reset in async_handle: closing CEM..")
             await self.cem.close()
-            self.entry.async_start_reauth(self.hass)
 
         return wsock

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "FlexMeasures for HACS",
-    "homeassistant": "2023.9.0",
+    "homeassistant": "2026.7.0",
     "render_readme": true
 }

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,7 +1,9 @@
 pytest
 pytest-cov
-pytest-homeassistant-custom-component==0.13.205 # fixing version, otherwise it will start installing all HA versions...
-pycares<4.6 # newer pycares spawns a shutdown thread that this pytest-homeassistant-custom-component version flags as lingering
+# Pinned: each release of this package targets one Home Assistant version.
+# 0.13.346 == Home Assistant 2026.7.2 (see the project's `ha_version` file) and
+# requires Python 3.14, which is what Home Assistant itself runs on.
+pytest-homeassistant-custom-component==0.13.346
 # NOTE: do not list flexmeasures-client here. Tests must run against the exact
 # version pinned in custom_components/flexmeasures_hacs/manifest.json, which is
 # installed separately (see .github/workflows/validate.yml). A guard test in

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,47 +16,14 @@ norecursedirs = .git
 asyncio_default_fixture_loop_scope = function
 asyncio_mode = auto
 addopts =
-    -p syrupy
-    --strict
+    --strict-markers
     --cov=custom_components
 
-[flake8]
-# https://github.com/ambv/black#line-length
-max-line-length = 88
-# E501: line too long
-# W503: Line break occurred before a binary operator
-# E203: Whitespace before ':'
-# D202 No blank lines allowed after function docstring
-# W504 line break after binary operator
-ignore =
-    E501,
-    W503,
-    E203,
-    D202,
-    W504
-
-[isort]
-# https://github.com/timothycrosley/isort
-# https://github.com/timothycrosley/isort/wiki/isort-Settings
-# splits long import on multiple lines indented by 4 spaces
-multi_line_output = 3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-default_section = THIRDPARTY
-known_first_party = custom_components,tests
-forced_separate = tests
-combine_as_imports = true
+# flake8 and isort settings used to live here; Ruff covers both now, see
+# .ruff.toml and .pre-commit-config.yaml.
 
 [mypy]
-python_version = 3.11
+python_version = 3.13
 ignore_errors = true
 follow_imports = silent
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,10 @@
 from collections.abc import Coroutine, Generator
 from typing import Any, cast
 
-import pytest
-
-from custom_components.flexmeasures_hacs.const import DOMAIN, WS_VIEW_URI
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import (
     ClientSessionGenerator,
@@ -17,37 +14,87 @@ from pytest_homeassistant_custom_component.typing import (
     WebSocketGenerator,
 )
 
+from custom_components.flexmeasures_hacs.config_flow import ConfigFlowHandler
+from custom_components.flexmeasures_hacs.const import DOMAIN, WS_VIEW_URI
+
+CURRENT_VERSION = ConfigFlowHandler.VERSION
+
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     yield
 
 
+S2_ENTRY_DATA = {
+    "asset_id": 20,
+    "consumption_sensor_id": 21,
+    "soc_minima_sensor_id": 1,
+    "soc_maxima_sensor_id": 2,
+    "fill_level_sensor_id": 3,
+    "fill_rate_sensor_id": 4,
+    "usage_forecast_sensor_id": 5,
+    "thp_fill_rate_sensor_id": 6,
+    "thp_efficiency_sensor_id": 7,
+    "nes_fill_rate_sensor_id": 8,
+    "nes_efficiency_sensor_id": 9,
+    "rm_discharge_sensor_id": 10,
+    "active_actuator_id_sensor_id": 15,
+    "state_of_charge_sensor_id": 16,
+    "leakage_behaviour_sensor_id": 17,
+}
+
+ENTRY_DATA = {
+    "url": "http://localhost:5000",
+    "username": "admin@admin.com",
+    "password": "admin",
+    "schedule_duration": "PT24H",
+    "power_sensor": 1,
+    "soc_sensor": 3,
+    "rm_discharge_sensor": 4,
+    "consumption_price_sensor": 2,
+    "production_price_sensor": 2,
+    "soc_unit": "kWh",
+    "soc_min": 0.0,
+    "soc_max": 0.001,
+    "s2": S2_ENTRY_DATA,
+}
+
+
+def build_entry(**overrides) -> MockConfigEntry:
+    """Build a config entry of the current version."""
+    data = {**ENTRY_DATA, **overrides.pop("data", {})}
+    return MockConfigEntry(
+        domain=DOMAIN,
+        version=CURRENT_VERSION,
+        data=data,
+        state=ConfigEntryState.NOT_LOADED,
+        **overrides,
+    )
+
+
 @pytest.fixture
 async def setup_fm_integration(hass: HomeAssistant):
     """FlexMeasures integration setup."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "url": "http://localhost:5000",
-            "username": "admin@admin.com",
-            "password": "admin",
-            "schedule_duration": "PT24H",
-            "power_sensor": 1,
-            "soc_sensor": 3,
-            "rm_discharge_sensor": 4,
-            "consumption_price_sensor": 2,
-            "production_price_sensor": 2,
-            "soc_unit": "kWh",
-            "soc_min": 0.0,
-            "soc_max": 0.001,
-        },
-        unique_id=1212121,
-        state=ConfigEntryState.NOT_LOADED,
-    )
+    entry = build_entry(unique_id="1212121")
 
     entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    return entry
+
+
+@pytest.fixture
+async def setup_second_fm_integration(hass: HomeAssistant, setup_fm_integration):
+    """A second FlexMeasures server, configured alongside the first."""
+    entry = build_entry(
+        unique_id="3434343",
+        title="FlexMeasures 2",
+        data={"url": "http://localhost:5001", "power_sensor": 7},
+    )
+
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     return entry
@@ -61,13 +108,16 @@ def fm_ws_client(
 ) -> WebSocketGenerator:
     """Websocket client fixture connected to websocket server."""
 
-    async def create_client(hass: HomeAssistant = hass) -> MockHAClientWebSocket:
-        """Create a websocket client."""
+    async def create_client(
+        hass: HomeAssistant = hass, entry_id: str | None = None
+    ) -> MockHAClientWebSocket:
+        """Create a websocket client, optionally for a specific config entry."""
 
         client = await aiohttp_client(hass.http.app)
-        websocket = await client.ws_connect(WS_VIEW_URI)
+        url = WS_VIEW_URI if entry_id is None else f"{WS_VIEW_URI}/{entry_id}"
+        websocket = await client.ws_connect(url)
 
-        def _get_next_id() -> Generator[int, None, None]:
+        def _get_next_id() -> Generator[int]:
             i = 0
             while True:
                 yield (i := i + 1)

--- a/tests/smoke/config/.storage/core.config_entries
+++ b/tests/smoke/config/.storage/core.config_entries
@@ -22,6 +22,8 @@
           "soc_min": 0.0,
           "soc_max": 0.001,
           "s2": {
+            "asset_id": 113,
+            "consumption_sensor_id": 357,
             "soc_minima_sensor_id": 218,
             "soc_maxima_sensor_id": 217,
             "fill_level_sensor_id": 215,

--- a/tests/smoke/ws_check.py
+++ b/tests/smoke/ws_check.py
@@ -21,17 +21,19 @@ RETRY_INTERVAL = 5
 
 
 async def try_handshake(base_url: str) -> bool:
-    async with aiohttp.ClientSession() as session:
-        async with session.ws_connect(base_url + WS_PATH) as ws:
-            msg = await ws.receive(timeout=30)
-            if msg.type != aiohttp.WSMsgType.TEXT:
-                print(f"Unexpected websocket message type: {msg.type}")
-                return False
-            handshake = json.loads(msg.data)
-            print(f"Received: {handshake}")
-            assert handshake["message_type"] == "Handshake", handshake
-            assert handshake["role"] == "CEM", handshake
-            return True
+    async with (
+        aiohttp.ClientSession() as session,
+        session.ws_connect(base_url + WS_PATH) as ws,
+    ):
+        msg = await ws.receive(timeout=30)
+        if msg.type != aiohttp.WSMsgType.TEXT:
+            print(f"Unexpected websocket message type: {msg.type}")
+            return False
+        handshake = json.loads(msg.data)
+        print(f"Received: {handshake}")
+        assert handshake["message_type"] == "Handshake", handshake
+        assert handshake["role"] == "CEM", handshake
+        return True
 
 
 async def main() -> int:
@@ -43,7 +45,7 @@ async def main() -> int:
             if await try_handshake(base_url):
                 print("Smoke test OK: CEM Handshake received.")
                 return 0
-        except (aiohttp.ClientError, asyncio.TimeoutError, AssertionError) as exc:
+        except (TimeoutError, aiohttp.ClientError, AssertionError) as exc:
             last_error = exc
         await asyncio.sleep(RETRY_INTERVAL)
     print(f"Smoke test FAILED: no CEM Handshake within {TIMEOUT}s: {last_error!r}")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -168,3 +169,29 @@ async def test_migration_v2_renames_the_misspelled_leakage_key(
     # Fields that did not exist in v2 stay unset: they identify entities on the
     # user's own FlexMeasures server, so there is nothing sensible to fill in.
     assert s2.get("asset_id") is None
+
+
+async def test_downgrade_is_refused_cleanly(hass: HomeAssistant) -> None:
+    """An entry from a newer release must not be silently mangled.
+
+    Home Assistant does not support downgrading a config entry across a major
+    version: it calls the older release's async_migrate_entry, which refuses.
+    The entry then sits in MIGRATION_ERROR until the user removes and re-adds
+    it -- rather than being loaded with data this version does not understand.
+    """
+    future_entry = MockConfigEntry(
+        version=CURRENT_VERSION + 1,
+        minor_version=1,
+        domain=DOMAIN,
+        title="FlexMeasures",
+        data=CONFIG,
+        source="user",
+    )
+    future_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(future_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert future_entry.state is ConfigEntryState.MIGRATION_ERROR
+    # The stored configuration is left untouched, so re-upgrading recovers it.
+    assert future_entry.version == CURRENT_VERSION + 1
+    assert future_entry.data == CONFIG

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,14 +1,19 @@
 """Test the FlexMeasures config flow."""
 
 from unittest.mock import patch
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.flexmeasures_hacs.config_flow import SCHEMA
-from custom_components.flexmeasures_hacs.const import DOMAIN
 
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.flexmeasures_hacs.config_flow import (
+    S2_SCHEMA,
+    SCHEMA,
+    schema_defaults,
+)
+from custom_components.flexmeasures_hacs.const import DOMAIN
+
+from .conftest import CURRENT_VERSION
 
 CONFIG = {
     "username": "admin@admin.com",
@@ -53,12 +58,15 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert (result["errors"] == {}) or result["errors"] is None
 
-    with patch(
-        "flexmeasures_client.FlexMeasuresClient.get_access_token",
-    ) as mock_validate_input, patch(
-        "custom_components.flexmeasures_hacs.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
+    with (
+        patch(
+            "flexmeasures_client.FlexMeasuresClient.get_access_token",
+        ) as mock_validate_input,
+        patch(
+            "custom_components.flexmeasures_hacs.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             CONFIG,
@@ -68,16 +76,30 @@ async def test_form(hass: HomeAssistant) -> None:
         assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result2["title"] == "FlexMeasures"
 
-        fields = {str(key): key for key in SCHEMA.schema}
+        defaults = schema_defaults(SCHEMA)
 
         for key, val in result2["options"].items():
             if key in CONFIG:
                 assert val == CONFIG[key]
             else:
-                assert val == fields[key].default()
+                assert val == defaults[key]
 
         mock_setup_entry.assert_called_once()
         mock_validate_input.assert_called_once()
+
+
+async def test_no_hardcoded_sensor_ids_as_defaults() -> None:
+    """The schemas must not default to the sensor ids of somebody's server.
+
+    Up to v0.3.9 the config flow defaulted to one pilot's FlexMeasures URL and
+    to the asset and sensor ids on that server, so a fresh install silently
+    pointed at somebody else's asset.
+    """
+    assert schema_defaults(S2_SCHEMA) == {}
+
+    defaults = schema_defaults(SCHEMA)
+    assert set(defaults) == {"schedule_duration", "soc_unit"}
+    assert "seita.energy" not in str(defaults)
 
 
 async def test_migration(hass: HomeAssistant) -> None:
@@ -100,16 +122,18 @@ async def test_migration(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries("flexmeasures_hacs")
 
     assert len(entries) == 1
-    assert entries[0].version == 3
+    assert entries[0].version == CURRENT_VERSION
     assert "s2" in entries[0].data
     assert all(S2_CONFIG[k] == v for (k, v) in entries[0].data["s2"].items())
 
 
-async def test_migration_v2_to_v3(hass: HomeAssistant) -> None:
-    """Test migrating a v2 entry: rename the misspelled leakage key, fill new S2 fields.
+async def test_migration_v2_renames_the_misspelled_leakage_key(
+    hass: HomeAssistant,
+) -> None:
+    """Test migrating a v2 entry: rename the misspelled leakage key.
 
     v2 entries were created by releases up to v0.3.7, whose S2 section used
-    leakage_beaviour_sensor_id (sic) and had no asset_id yet.
+    leakage_beaviour_sensor_id (sic), which client versions >=0.8 reject.
     """
     old_s2 = {
         k: v
@@ -133,14 +157,14 @@ async def test_migration_v2_to_v3(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries("flexmeasures_hacs")
 
     assert len(entries) == 1
-    assert entries[0].version == 3
+    assert entries[0].version == CURRENT_VERSION
     s2 = entries[0].data["s2"]
     # The configured value survives under the corrected key
     assert "leakage_beaviour_sensor_id" not in s2
     assert s2["leakage_behaviour_sensor_id"] == 99
     assert entries[0].options["s2"] == {"leakage_behaviour_sensor_id": 99}
-    # Fields that did not exist in v2 are filled with schema defaults
-    assert "asset_id" in s2
-    assert "consumption_sensor_id" in s2
     # Pre-existing values are preserved
     assert s2["soc_minima_sensor_id"] == S2_CONFIG["soc_minima_sensor_id"]
+    # Fields that did not exist in v2 stay unset: they identify entities on the
+    # user's own FlexMeasures server, so there is nothing sensible to fill in.
+    assert s2.get("asset_id") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -88,3 +88,48 @@ async def test_two_entries_keep_their_own_state(
     await hass.config_entries.async_unload(second.entry_id)
     await hass.async_block_till_done()
     assert hass.services.has_service(DOMAIN, "trigger_and_get_schedule")
+
+
+async def test_warns_when_the_flexmeasures_server_is_too_old(
+    hass: HomeAssistant, caplog
+) -> None:
+    """An old FlexMeasures server makes the sensor-data services 404 at call time.
+
+    flexmeasures-client >=0.8 uses endpoints that FlexMeasures only serves from
+    0.28.0 on, so say so at startup instead of letting an automation find out.
+    """
+    from .conftest import build_entry
+
+    entry = build_entry(unique_id="oldserver")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "flexmeasures_client.client.FlexMeasuresClient.get_versions",
+        return_value={"server_version": "0.25.0"},
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED  # a warning, not a failure
+    assert "0.25.0" in caplog.text
+    assert "0.28.0 or above" in caplog.text
+
+
+async def test_no_warning_for_a_recent_flexmeasures_server(
+    hass: HomeAssistant, caplog
+) -> None:
+    """A recent enough server must not produce the version warning."""
+    from .conftest import build_entry
+
+    entry = build_entry(unique_id="newserver")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "flexmeasures_client.client.FlexMeasuresClient.get_versions",
+        return_value={"server_version": "0.33.1"},
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state == ConfigEntryState.LOADED
+    assert "or above" not in caplog.text

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,9 +1,12 @@
 """Test initialization of FlexMeasures integration."""
 
-from custom_components.flexmeasures_hacs.const import DOMAIN
-from custom_components.flexmeasures_hacs.services import SERVICES
+from unittest.mock import patch
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+
+from custom_components.flexmeasures_hacs.const import DOMAIN
+from custom_components.flexmeasures_hacs.services import SERVICE_NAMES
 
 
 async def test_load_unload_config_entry(
@@ -15,15 +18,73 @@ async def test_load_unload_config_entry(
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
-    for service in SERVICES:
-        assert hass.services.has_service(DOMAIN, service["service"])
+    for service_name in SERVICE_NAMES:
+        assert hass.services.has_service(DOMAIN, service_name)
 
     assert entry.state == ConfigEntryState.LOADED
+    assert entry.runtime_data.client is not None
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    for service in SERVICES:
-        assert not hass.services.has_service(DOMAIN, service["service"])
+    for service_name in SERVICE_NAMES:
+        assert not hass.services.has_service(DOMAIN, service_name)
 
     assert entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_services_act_on_the_current_entry_after_a_reload(
+    hass: HomeAssistant, setup_fm_integration
+) -> None:
+    """A reload must not leave services bound to the entry's previous runtime data.
+
+    Services used to be registered per config entry, and the registration list
+    was mutated in place, so after a reload (which every options change causes)
+    the handlers bound to the *old* entry state were re-registered.
+    """
+    entry = setup_fm_integration
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.LOADED
+
+    with patch(
+        "flexmeasures_client.client.FlexMeasuresClient.trigger_and_get_schedule",
+        return_value={"values": [1.0], "unit": "MW"},
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "trigger_and_get_schedule",
+            service_data={"soc_at_start": 10},
+            blocking=True,
+        )
+
+    # The schedule landed on the entry's *current* runtime data, i.e. the
+    # service resolved the reloaded entry and not a stale closure.
+    assert entry.runtime_data.schedule_state.schedule
+
+
+async def test_two_entries_keep_their_own_state(
+    hass: HomeAssistant, setup_fm_integration, setup_second_fm_integration
+) -> None:
+    """Two FlexMeasures servers can be configured side by side."""
+    first = setup_fm_integration
+    second = setup_second_fm_integration
+
+    assert len(hass.config_entries.async_loaded_entries(DOMAIN)) == 2
+    assert first.runtime_data is not second.runtime_data
+    assert first.runtime_data.client.port == 5000
+    assert second.runtime_data.client.port == 5001
+
+    # Each entry gets its own schedule sensor.
+    entity_ids = [
+        state.entity_id
+        for state in hass.states.async_all("sensor")
+        if state.entity_id.startswith("sensor.")
+    ]
+    assert len(entity_ids) == 2
+
+    # Unloading one entry keeps the services around for the other.
+    await hass.config_entries.async_unload(second.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(DOMAIN, "trigger_and_get_schedule")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.flexmeasures_hacs.const import DOMAIN
 from custom_components.flexmeasures_hacs.services import SERVICE_NAMES
@@ -133,3 +134,40 @@ async def test_no_warning_for_a_recent_flexmeasures_server(
 
     assert entry.state == ConfigEntryState.LOADED
     assert "or above" not in caplog.text
+
+
+async def test_datastore_migration_keeps_the_legacy_store_for_rollback(
+    hass: HomeAssistant,
+) -> None:
+    """Migrating the S2 datastore must copy, not move.
+
+    Rolling back to an older release means re-adding the entry, and that older
+    release reads its S2 state from the legacy store, so it has to survive.
+    """
+    from homeassistant.helpers.storage import Store
+
+    from custom_components.flexmeasures_hacs.datastore import (
+        LEGACY_STORAGE_KEY,
+        STORAGE_VERSION,
+        storage_key,
+    )
+
+    from .conftest import ENTRY_DATA
+
+    legacy_state = {"some-cem-state": 42}
+    await Store(hass, STORAGE_VERSION, LEGACY_STORAGE_KEY).async_save(legacy_state)
+
+    # A v3 entry, i.e. one created before the datastore became per-entry.
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=3, data=ENTRY_DATA, source="user", unique_id="rollback"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry_store = Store(hass, STORAGE_VERSION, storage_key(entry.entry_id))
+    assert await entry_store.async_load() == legacy_state
+    # ... and the legacy store is still there for an older release to read.
+    assert await Store(hass, STORAGE_VERSION, LEGACY_STORAGE_KEY).async_load() == (
+        legacy_state
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -9,12 +9,12 @@ manifest.
 
 from __future__ import annotations
 
-import json
 from importlib.metadata import PackageNotFoundError, version
+import json
 from pathlib import Path
 
-import pytest
 from packaging.requirements import Requirement
+import pytest
 
 MANIFEST_PATH = (
     Path(__file__).parent.parent

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3,6 +3,10 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+import homeassistant.util.dt as dt_util
+from homeassistant.util.dt import parse_duration
 import pytest
 from s2python.common import ControlType
 
@@ -12,9 +16,6 @@ from custom_components.flexmeasures_hacs.const import (
     SERVICE_CHANGE_CONTROL_TYPE,
 )
 from custom_components.flexmeasures_hacs.services import time_ceil
-from homeassistant.core import HomeAssistant
-import homeassistant.util.dt as dt_util
-from homeassistant.util.dt import parse_duration
 
 
 @pytest.mark.skip(
@@ -140,3 +141,39 @@ async def test_get_measurements(hass: HomeAssistant, setup_fm_integration) -> No
             unit="kWh",
             resolution="PT15M",
         )
+
+
+async def test_service_needs_entry_id_when_several_servers_are_configured(
+    hass: HomeAssistant, setup_fm_integration, setup_second_fm_integration
+) -> None:
+    """With two servers configured, a service call must say which one it means."""
+    with pytest.raises(ServiceValidationError, match="entry_id"):
+        await hass.services.async_call(
+            DOMAIN,
+            "trigger_and_get_schedule",
+            service_data={"soc_at_start": 10},
+            blocking=True,
+        )
+
+
+async def test_service_targets_the_requested_entry(
+    hass: HomeAssistant, setup_fm_integration, setup_second_fm_integration
+) -> None:
+    """entry_id picks the FlexMeasures server a service call acts on."""
+    second = setup_second_fm_integration
+
+    with patch(
+        "flexmeasures_client.client.FlexMeasuresClient.trigger_and_get_schedule",
+        return_value={"values": [0.5], "unit": "MW"},
+    ) as mocked_trigger:
+        await hass.services.async_call(
+            DOMAIN,
+            "trigger_and_get_schedule",
+            service_data={"soc_at_start": 10, "entry_id": second.entry_id},
+            blocking=True,
+        )
+
+    # The second entry configures power_sensor 7, the first one sensor 1.
+    assert mocked_trigger.await_args.kwargs["sensor_id"] == 7
+    assert second.runtime_data.schedule_state.schedule
+    assert not setup_fm_integration.runtime_data.schedule_state.schedule

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -2,7 +2,32 @@
 
 # pytest ./tests/components/flexmeasures/ --cov=homeassistant.components.flexmeasures --cov-report term-missing -vv
 
+import logging
+
+import pytest
+
 from homeassistant.core import HomeAssistant
+
+
+async def test_websocket_connection_does_not_log_credentials(
+    hass: HomeAssistant,
+    setup_fm_integration,
+    fm_ws_client,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Opening a websocket connection must not leak the FlexMeasures credentials.
+
+    Up to v0.3.8, the handler logged the whole FlexMeasuresClient at WARNING
+    level. It is a dataclass, so its repr contains the password in plain text,
+    which ended up in the Home Assistant log on every connection.
+    """
+    password = setup_fm_integration.data["password"]
+    with caplog.at_level(logging.DEBUG):
+        await fm_ws_client(hass)
+        await hass.async_block_till_done()
+
+    assert password not in caplog.text
+    assert setup_fm_integration.data["username"] not in caplog.text
 
 
 async def test_cem_processes_websocket_msg(

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -31,27 +31,6 @@ async def test_websocket_connection_does_not_log_credentials(
     assert setup_fm_integration.data["username"] not in caplog.text
 
 
-async def test_websocket_connection_does_not_log_credentials(
-    hass: HomeAssistant,
-    setup_fm_integration,
-    fm_ws_client,
-    caplog: pytest.LogCaptureFixture,
-):
-    """Opening a websocket connection must not leak the FlexMeasures credentials.
-
-    Up to v0.3.8, the handler logged the whole FlexMeasuresClient at WARNING
-    level. It is a dataclass, so its repr contains the password in plain text,
-    which ended up in the Home Assistant log on every connection.
-    """
-    password = setup_fm_integration.data["password"]
-    with caplog.at_level(logging.DEBUG):
-        await fm_ws_client(hass)
-        await hass.async_block_till_done()
-
-    assert password not in caplog.text
-    assert setup_fm_integration.data["username"] not in caplog.text
-
-
 async def test_cem_processes_websocket_msg(
     hass: HomeAssistant, setup_fm_integration, fm_websocket_client
 ):

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -2,11 +2,12 @@
 
 # pytest ./tests/components/flexmeasures/ --cov=homeassistant.components.flexmeasures --cov-report term-missing -vv
 
+from http import HTTPStatus
 import logging
 
-import pytest
-
+from aiohttp import WSServerHandshakeError
 from homeassistant.core import HomeAssistant
+import pytest
 
 
 async def test_websocket_connection_does_not_log_credentials(
@@ -47,3 +48,23 @@ async def test_cem_processes_websocket_msg(
 
     assert msg["message_type"] == "Handshake"
     assert msg["role"] == "CEM"
+
+
+async def test_websocket_targets_the_requested_entry(
+    hass: HomeAssistant, setup_fm_integration, setup_second_fm_integration, fm_ws_client
+) -> None:
+    """A Resource Manager picks its FlexMeasures server by entry id in the path."""
+    second = setup_second_fm_integration
+
+    # With two entries loaded, the bare endpoint cannot know which one to use.
+    with pytest.raises(WSServerHandshakeError) as err:
+        await fm_ws_client(hass)
+    assert err.value.status == HTTPStatus.BAD_REQUEST
+
+    websocket = await fm_ws_client(hass, entry_id=second.entry_id)
+    msg = await websocket.receive_json()
+
+    assert msg["message_type"] == "Handshake"
+    assert msg["role"] == "CEM"
+    assert second.runtime_data.cem is not None
+    assert setup_fm_integration.runtime_data.cem is None


### PR DESCRIPTION
Follows v0.3.9. Two bugs fixed here were found while doing this work; both are described below.

## Several FlexMeasures servers per Home Assistant (closes #23)

Runtime state moves from the global `hass.data[DOMAIN]` onto the config entry (`entry.runtime_data`, the current HA pattern), so the integration can be added more than once. Each entry gets its own client, S2 datastore, schedule state, device and schedule sensor.

- **Services** are now registered once for the integration and resolve the entry per call, via an optional `entry_id` field.
- **Resource Managers** reach a specific entry at `/api/websocket_custom/<entry_id>`.
- With a single entry configured (i.e. every install today), **nothing changes for the user**: the bare endpoint and the field-less service calls keep working.

This supersedes the stale #24, which took a different route.

### Bug found: services were bound to a stale entry after every reload

`async_setup_services` popped `service_func_name` out of the *module-level* `SERVICES` dicts and stored the closure back into them. On the second setup — and every options change reloads the entry — the key was gone, so the **closures bound to the previous entry were re-registered**. Registering once and resolving the entry per call removes the whole class of bug. Covered by `test_services_act_on_the_current_entry_after_a_reload`.

## Bug found: the config flow defaulted to a pilot's own server

The config flow shipped `https://seita.energy` as the default URL, with `example@example.com` / `password` as credentials, and defaulted every S2 field to the asset and sensor ids **on that pilot's FlexMeasures server** (`asset_id: 113`, `soc_minima_sensor_id: 218`, …). A fresh install that clicked through the S2 section would silently point at somebody else's asset.

Defaults are gone. Since ids can no longer be silently wrong, the S2 websocket now **refuses a connection with a clear message** when the S2 section is not configured, instead of running the control path against unset ids. Covered by `test_no_hardcoded_sensor_ids_as_defaults`.

## Migration (v3 → v4)

Existing installs keep working:
- the schedule sensor's unique id is re-scoped to the entry via the entity registry, so **the entity and its history survive**;
- the shared S2 datastore is moved into the entry's own store.

## Other modernization

- **websockets**: `KEY_HASS` instead of the deprecated `request.app["hass"]`; stop treating *any* exception while handling an S2 message as an auth failure (it kicked off a reauth flow that hid the real bug).
- **services**: replace `pytz` — which is not a declared requirement and was only present transitively via pandas — with `homeassistant.util.dt`; stop logging schedule payloads at INFO.
- **sensor**: `has_entity_name`, a translation key, a device per entry, and push updates (`async_write_ha_state`) instead of `async_schedule_update_ha_state(True)`.
- **datastore**: debounce saves via `Store.async_delay_save` instead of spawning a save task per mutation (the `_save_delay` field existed but was never used).
- **manifest**: drop the unused `isodate` requirement; fix `documentation`/`issue_tracker` URLs, which pointed at the old repo name; declare `integration_type`, and `iot_class: cloud_push` (the schedule arrives by push, it is not polled).
- **toolchain**: Ruff replaces black + flake8 + isort + pyupgrade (they ran side by side with partly contradicting settings); tests run on **Python 3.14** against the **Home Assistant 2026.7.2** test harness (`pytest-homeassistant-custom-component==0.13.346`); `hacs.json` now states the HA version we actually test, instead of 2023.9.
- **README**: the example automations still used the pre-rename domain (`flexmeasures.` instead of `flexmeasures_hacs.`), so they could not have worked. Also documents multi-server usage.

## Verification

`17 passed` locally (up from 12), including new coverage for the reload bug, two entries side by side, entry-targeted service calls and websocket connections, and the absence of hardcoded defaults. My local disk cannot hold the HA 2026.7 test harness, so **CI is the authoritative check** for the Python 3.14 / HA 2026.7.2 bump — plus the real-HA smoke job, which boots an actual Home Assistant container with the component mounted.

## Deliberately not done

- **Websocket authentication.** The endpoint is still `requires_auth = False`, i.e. anyone who can reach Home Assistant can drive the S2 control path. Fixing it properly needs an answer to: *can the TUNES Resource Manager send an `Authorization: Bearer` header?* If it can, this should become a long-lived-token endpoint (behind a config option, to not break the pilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
